### PR TITLE
feat(ci): RANCHER-2861 add per-entry constraint map and descriptor template support

### DIFF
--- a/.github/actions/build-constraint-map/action.yml
+++ b/.github/actions/build-constraint-map/action.yml
@@ -1,0 +1,30 @@
+name: 'Build Constraint Map'
+description: 'Build per-entry constraint maps (minor|patch|exact) from descriptor template JSON'
+author: 'FOLIO Kitfox'
+
+inputs:
+  eureka-components:
+    description: 'JSON array of eureka-components from the descriptor template'
+    required: true
+  applications:
+    description: 'JSON object of applications (required/optional) from the descriptor template'
+    required: true
+
+outputs:
+  component-constraint-map:
+    description: 'JSON object mapping component names to constraint types (minor|patch|exact)'
+    value: ${{ steps.build.outputs.component-constraint-map }}
+  app-constraint-map:
+    description: 'JSON object mapping application names to constraint types (minor|patch|exact)'
+    value: ${{ steps.build.outputs.app-constraint-map }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Build constraint map'
+      id: build
+      shell: bash
+      env:
+        EUREKA_COMPONENTS: ${{ inputs.eureka-components }}
+        APPLICATIONS: ${{ inputs.applications }}
+      run: python3 "${{ github.action_path }}/build_constraint_map.py"

--- a/.github/actions/build-constraint-map/build_constraint_map.py
+++ b/.github/actions/build-constraint-map/build_constraint_map.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Build per-entry constraint maps from descriptor JSON for eureka-components and applications.
+
+Reads EUREKA_COMPONENTS and APPLICATIONS environment variables (JSON strings),
+derives a constraint map (minor|patch|exact) from version prefixes (^|~|plain),
+and writes component-constraint-map and app-constraint-map to GITHUB_OUTPUT.
+"""
+
+import json
+import os
+import sys
+
+
+def extract_constraints(items: list[dict]) -> dict[str, str]:
+    result = {}
+    for item in items:
+        v = item.get('version', '')
+        if v.startswith('^'):
+            result[item['name']] = 'minor'
+        elif v.startswith('~'):
+            result[item['name']] = 'patch'
+        else:
+            result[item['name']] = 'exact'
+    return result
+
+
+def main() -> None:
+    eureka_components_json = os.environ.get('EUREKA_COMPONENTS', '')
+    applications_json = os.environ.get('APPLICATIONS', '')
+
+    if not eureka_components_json or not applications_json:
+        print('::error::EUREKA_COMPONENTS and APPLICATIONS environment variables are required', file=sys.stderr)
+        sys.exit(1)
+
+    components = json.loads(eureka_components_json)
+    apps_obj = json.loads(applications_json)
+
+    component_map = extract_constraints(components)
+    app_items = apps_obj.get('required', []) + apps_obj.get('optional', [])
+    app_map = extract_constraints(app_items)
+
+    gh_output = os.environ.get('GITHUB_OUTPUT', '')
+    if not gh_output:
+        print('::error::GITHUB_OUTPUT environment variable is not set', file=sys.stderr)
+        sys.exit(1)
+
+    with open(gh_output, 'a') as f:
+        f.write(f'component-constraint-map={json.dumps(component_map)}\n')
+        f.write(f'app-constraint-map={json.dumps(app_map)}\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/actions/release-update-notification/action.yml
+++ b/.github/actions/release-update-notification/action.yml
@@ -145,7 +145,7 @@ runs:
       # Parse package diff JSON and format as plain text for Slack
       if [[ -n "$PACKAGE_DIFF_JSON" && "$PACKAGE_DIFF_JSON" != "[]" ]]; then
         UI_DEPS=$(echo "$PACKAGE_DIFF_JSON" | jq -r '
-          map("\(.name): \(.old_version) → \(.new_version)") | 
+          map("\(.name): \(.change.old) → \(.change.new)") |
           join("\n")
         ')
         

--- a/.github/actions/update-applications/action.yml
+++ b/.github/actions/update-applications/action.yml
@@ -60,6 +60,12 @@ inputs:
     description: Level of logging verbosity (INFO, DEBUG, WARNING, ERROR)
     required: false
     default: 'INFO'
+  constraint-map:
+    description: >-
+      JSON object mapping application name to resolved scope (minor|patch|exact).
+      Overrides global filter-scope per entry.
+    required: false
+    default: '{}'
 
 outputs:
   updated-applications:
@@ -107,6 +113,7 @@ runs:
         RETRY_BACKOFF: ${{ inputs.retry-backoff }}
         PYTHONUNBUFFERED: '1'
         LOG_LEVEL: ${{ inputs.log-level }}
+        CONSTRAINT_MAP: ${{ inputs.constraint-map }}
       run: |
         set -euo pipefail
         IFS=$'\n\t'

--- a/.github/actions/update-applications/update-applications.py
+++ b/.github/actions/update-applications/update-applications.py
@@ -39,6 +39,21 @@ MAX_RETRIES = int(os.getenv("MAX_RETRIES", "3"))            # HTTP request retri
 RETRY_BACKOFF = float(os.getenv("RETRY_BACKOFF", "1.0"))    # Base backoff time in seconds
 
 # ---------------------------------------------------------------------------
+# Constraint parsing
+# ---------------------------------------------------------------------------
+PREFIX_TO_SCOPE = {'^': 'minor', '~': 'patch', '': 'exact'}
+
+
+def parse_constraint(version_str):
+    """Returns (prefix, base_version). prefix is '^', '~', or ''.
+    Raises ValueError for unsupported constraint prefixes."""
+    if version_str.startswith(('^', '~')):
+        return version_str[0], version_str[1:]
+    if version_str and version_str[0].isdigit():
+        return '', version_str
+    raise ValueError("Unsupported constraint prefix in version '%s'" % version_str)
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 def validate_configuration(filter_scope, sort_order):
@@ -170,7 +185,7 @@ def decide_update(current_version, candidate_versions, sort_order):
 # ---------------------------------------------------------------------------
 # Update logic
 # ---------------------------------------------------------------------------
-def update_applications(applications, filter_scope, sort_order):
+def update_applications(applications, filter_scope, sort_order, constraint_map=None):
     if not applications:
         logger.info("No applications provided")
         return applications
@@ -180,6 +195,10 @@ def update_applications(applications, filter_scope, sort_order):
     for app in applications:
         name = app.get("name", "<unknown>")
         current = app.get("version", "0.0.0")
+        entry_scope = constraint_map.get(name, filter_scope) if constraint_map else filter_scope
+        if entry_scope == 'exact':
+            logger.info("Processing: %s (current: %s) - exact pin, skipping query" % (name, current))
+            continue
         logger.info("Processing: %s (current: %s)" % (name, current))
         try:
             all_versions = fetch_app_versions(name)
@@ -190,7 +209,7 @@ def update_applications(applications, filter_scope, sort_order):
         if not all_versions:
             logger.info("  No versions found")
             continue
-        filtered = filter_versions(all_versions, current, filter_scope)
+        filtered = filter_versions(all_versions, current, entry_scope)
         logger.info("  Filtered versions: %s" % filtered)
         if not filtered:
             logger.info("  No candidate versions in scope")
@@ -227,7 +246,7 @@ def print_grouped(grouped):
 # ---------------------------------------------------------------------------
 # Process applications from JSON
 # ---------------------------------------------------------------------------
-def process_applications_json(applications_json, filter_scope, sort_order):
+def process_applications_json(applications_json, filter_scope, sort_order, constraint_map=None):
     try:
         payload = json.loads(applications_json)
     except json.JSONDecodeError as exc:
@@ -262,8 +281,21 @@ def process_applications_json(applications_json, filter_scope, sort_order):
     logger.info("Original applications:")
     for app in flat:
         logger.info(" - %s: %s" % (app['name'], app['version']))
+    # Strip constraint prefixes from version strings and derive per-entry scope map
+    derived_map = {}
+    for app in flat:
+        try:
+            prefix, base_version = parse_constraint(app['version'])
+        except ValueError as exc:
+            logger.error("Invalid version constraint for %s: %s" % (app.get('name'), exc))
+            return None
+        app['version'] = base_version
+        if prefix:
+            derived_map[app['name']] = PREFIX_TO_SCOPE[prefix]
+    # Resolve final constraint map: explicit constraint_map takes precedence over derived
+    resolved_map = {**derived_map, **(constraint_map or {})} or None
     logger.info("=" * 40)
-    update_applications(flat, filter_scope, sort_order)
+    update_applications(flat, filter_scope, sort_order, constraint_map=resolved_map)
     logger.info("=" * 40)
     logger.info("Updated applications:")
     for app in flat:
@@ -284,6 +316,8 @@ def parse_args():
     parser.add_argument('--data', type=str, help='JSON string containing application data')
     parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], default=LOG_LEVEL,
                         help='Logging verbosity level (default: %s)' % LOG_LEVEL)
+    parser.add_argument('--constraint-map', type=str, default=None,
+                        help='JSON object mapping app name to scope (minor|patch|exact)')
     return parser.parse_args()
 
 # ---------------------------------------------------------------------------
@@ -301,7 +335,15 @@ def main():
         if not applications_json:
             logger.error("No application data provided. Use --data argument or APPLICATIONS_JSON environment variable.")
             return 1
-        output_obj = process_applications_json(applications_json, filter_scope, sort_order)
+        constraint_map_json = args.constraint_map or os.getenv("CONSTRAINT_MAP")
+        constraint_map = None
+        if constraint_map_json:
+            try:
+                constraint_map = json.loads(constraint_map_json) or None
+            except json.JSONDecodeError as exc:
+                logger.error("Invalid CONSTRAINT_MAP JSON: %s" % exc)
+                return 1
+        output_obj = process_applications_json(applications_json, filter_scope, sort_order, constraint_map=constraint_map)
         if output_obj is None:
             return 1
         serialized = json.dumps(output_obj, separators=(",", ":"))  # removed sort_keys=True to preserve original object key order

--- a/.github/actions/update-eureka-components/action.yml
+++ b/.github/actions/update-eureka-components/action.yml
@@ -38,6 +38,12 @@ inputs:
     description: Level of logging verbosity (INFO, DEBUG, WARNING, ERROR)
     required: false
     default: 'INFO'
+  constraint-map:
+    description: >-
+      JSON object mapping component name to resolved scope (minor|patch|exact).
+      Overrides global filter-scope per entry.
+    required: false
+    default: '{}'
 
 outputs:
   updated-components:
@@ -81,6 +87,7 @@ runs:
         COMPONENTS_JSON: '${{ inputs.components }}'
         FILTER_SCOPE: '${{ inputs.filter-scope }}'
         SORT_ORDER: '${{ inputs.sort-order }}'
+        CONSTRAINT_MAP: '${{ inputs.constraint-map }}'
       run: |
         set -euo pipefail
         IFS=$'\n\t'

--- a/.github/actions/update-eureka-components/update-eureka-components.py
+++ b/.github/actions/update-eureka-components/update-eureka-components.py
@@ -59,6 +59,21 @@ RETRY_BACKOFF_BASE = 2
 RETRY_INITIAL_WAIT = 1  # seconds
 
 # ---------------------------------------------------------------------------
+# Constraint parsing
+# ---------------------------------------------------------------------------
+PREFIX_TO_SCOPE = {'^': 'minor', '~': 'patch', '': 'exact'}
+
+
+def parse_constraint(version_str: str) -> Tuple[str, str]:
+    """Returns (prefix, base_version). prefix is '^', '~', or ''.
+    Raises ValueError for unsupported constraint prefixes."""
+    if version_str.startswith(('^', '~')):
+        return version_str[0], version_str[1:]
+    if version_str and version_str[0].isdigit():
+        return '', version_str
+    raise ValueError(f"Unsupported constraint prefix in version '{version_str}'")
+
+# ---------------------------------------------------------------------------
 # Validation helpers
 # ---------------------------------------------------------------------------
 def validate_configuration(filter_scope: str, sort_order: str) -> None:
@@ -244,7 +259,12 @@ def decide_update(current_version: str, candidate_versions: Sequence[str], sort_
     return newest if is_newer(current_version, newest) else None
 
 
-def update_components(components: List[Dict[str, str]], filter_scope: str, sort_order: str) -> List[Dict[str, str]]:
+def update_components(
+    components: List[Dict[str, str]],
+    filter_scope: str,
+    sort_order: str,
+    constraint_map: Optional[Dict[str, str]] = None,
+) -> List[Dict[str, str]]:
     """
     Update component versions in-place when a newer release (with existing Docker image) is found.
     Returns the same list (mutated) for convenience.
@@ -261,11 +281,15 @@ def update_components(components: List[Dict[str, str]], filter_scope: str, sort_
     for comp in components:
         name = comp.get("name", "unknown")
         current_version = comp.get("version", "0.0.0")
+        entry_scope = constraint_map.get(name, filter_scope) if constraint_map else filter_scope
+        if entry_scope == 'exact':
+            logger.info(f"Processing: {name} (current: {current_version}) - exact pin, skipping query")
+            continue
         logger.info(f"Processing: {name} (current: {current_version})")
 
         try:
             all_tags = fetch_repo_release_tags(name, session=session)
-            filtered = filter_versions(all_tags, current_version, filter_scope)
+            filtered = filter_versions(all_tags, current_version, entry_scope)
             logger.debug(f"  All tags: {all_tags}")
             logger.info(f"  Filtered versions: {filtered}")
 
@@ -302,6 +326,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('--sort-order', choices=['asc', 'desc'], default='asc',
                         help='Sort order when evaluating versions (default: asc)')
     parser.add_argument('--data', type=str, help='JSON string containing component data')
+    parser.add_argument('--constraint-map', type=str, default=None,
+                        help='JSON object mapping component name to scope (minor|patch|exact)')
     return parser.parse_args()
 
 # ---------------------------------------------------------------------------
@@ -334,12 +360,37 @@ def main() -> int:
             if not isinstance(item, dict) or "name" not in item or "version" not in item:
                 raise ValueError(f"Item at index {idx} must be an object with 'name' and 'version'")
 
+        # Read constraint map: CLI arg takes precedence over env var
+        constraint_map_json = args.constraint_map or os.getenv("CONSTRAINT_MAP")
+        constraint_map: Optional[Dict[str, str]] = None
+        if constraint_map_json:
+            try:
+                constraint_map = json.loads(constraint_map_json) or None
+            except json.JSONDecodeError as exc:
+                logger.error(f"Invalid CONSTRAINT_MAP JSON: {exc}")
+                return 1
+
+        # Strip constraint prefixes from version strings and derive per-entry scope map
+        derived_map: Dict[str, str] = {}
+        for comp in components_data:
+            try:
+                prefix, base_version = parse_constraint(comp['version'])
+            except ValueError as exc:
+                logger.error(f"Invalid version constraint for {comp.get('name')}: {exc}")
+                return 1
+            comp['version'] = base_version
+            if prefix:
+                derived_map[comp['name']] = PREFIX_TO_SCOPE[prefix]
+
+        # Resolve final constraint map: explicit constraint_map takes precedence over derived
+        resolved_map: Optional[Dict[str, str]] = {**derived_map, **(constraint_map or {})} or None
+
         logger.info("Original components:")
         for c in components_data:
             logger.info(f" - {c['name']}: {c['version']}")
 
         logger.info("=" * 40)
-        updated = update_components(components_data, filter_scope, sort_order)
+        updated = update_components(components_data, filter_scope, sort_order, constraint_map=resolved_map)
         logger.info("=" * 40)
 
         logger.info("Updated components:")

--- a/.github/actions/validate-descriptor-template/action.yml
+++ b/.github/actions/validate-descriptor-template/action.yml
@@ -1,0 +1,17 @@
+name: 'Validate Descriptor Template'
+description: 'Validate constraint-prefixed versions in a platform descriptor template file'
+author: 'FOLIO Kitfox'
+
+inputs:
+  template-file:
+    description: 'Path to the descriptor template JSON file'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Validate descriptor template'
+      shell: bash
+      env:
+        TEMPLATE_FILE: ${{ inputs.template-file }}
+      run: python3 "${{ github.action_path }}/validate_descriptor_template.py"

--- a/.github/actions/validate-descriptor-template/validate_descriptor_template.py
+++ b/.github/actions/validate-descriptor-template/validate_descriptor_template.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate constraint-prefixed versions in a platform descriptor template file.
+
+Reads the template file path from the TEMPLATE_FILE environment variable.
+
+Exit codes:
+  0 - validation passed
+  1 - validation failed (errors printed as GitHub Actions annotations)
+"""
+
+import json
+import os
+import re
+import sys
+
+CONSTRAINT_RE = re.compile(r'^[\^~]?\d+\.\d+\.\d+$')
+PLAIN_VERSION_RE = re.compile(r'^(\d+\.\d+\.\d+|R\d+-\d{4})')
+
+
+def validate(template_file: str) -> list[str]:
+    with open(template_file) as f:
+        tmpl = json.load(f)
+
+    errors = []
+
+    if not PLAIN_VERSION_RE.match(tmpl.get('version', '')):
+        errors.append("top-level 'version' must be plain X.Y.Z or Rx-YYYY")
+
+    for comp in tmpl.get('eureka-components', []):
+        v = comp.get('version', '')
+        if not CONSTRAINT_RE.match(v):
+            errors.append(f"eureka-components[{comp['name']}].version='{v}' is invalid")
+
+    for group in ('required', 'optional'):
+        for app in tmpl.get('applications', {}).get(group, []):
+            v = app.get('version', '')
+            if not CONSTRAINT_RE.match(v):
+                errors.append(f"applications.{group}[{app['name']}].version='{v}' is invalid")
+
+    return errors
+
+
+def main() -> None:
+    template_file = os.environ.get('TEMPLATE_FILE', '')
+    if not template_file:
+        print('::error::TEMPLATE_FILE environment variable is required', file=sys.stderr)
+        sys.exit(1)
+
+    errors = validate(template_file)
+    if errors:
+        for e in errors:
+            print(f'::error::{e}')
+        sys.exit(1)
+
+    print('::notice::Template validation passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/build-constraint-map.py
+++ b/.github/scripts/build-constraint-map.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Build per-entry constraint maps from descriptor JSON for eureka-components and applications.
+
+Reads EUREKA_COMPONENTS and APPLICATIONS environment variables (JSON strings),
+derives a constraint map (minor|patch|exact) from version prefixes (^|~|plain),
+and writes component_constraint_map and app_constraint_map to GITHUB_OUTPUT.
+
+Usage: python3 build-constraint-map.py
+"""
+
+import json
+import os
+import sys
+
+
+def extract_constraints(items):
+    result = {}
+    for item in items:
+        v = item.get('version', '')
+        if v.startswith('^'):
+            result[item['name']] = 'minor'
+        elif v.startswith('~'):
+            result[item['name']] = 'patch'
+        else:
+            result[item['name']] = 'exact'
+    return result
+
+
+def main():
+    eureka_components_json = os.environ.get('EUREKA_COMPONENTS', '')
+    applications_json = os.environ.get('APPLICATIONS', '')
+
+    if not eureka_components_json or not applications_json:
+        print("::error::EUREKA_COMPONENTS and APPLICATIONS environment variables are required", file=sys.stderr)
+        sys.exit(1)
+
+    components = json.loads(eureka_components_json)
+    apps_obj = json.loads(applications_json)
+
+    component_map = extract_constraints(components)
+    app_items = apps_obj.get('required', []) + apps_obj.get('optional', [])
+    app_map = extract_constraints(app_items)
+
+    gh_output = os.environ.get('GITHUB_OUTPUT', '')
+    if not gh_output:
+        print("::error::GITHUB_OUTPUT environment variable is not set", file=sys.stderr)
+        sys.exit(1)
+
+    with open(gh_output, 'a') as f:
+        f.write(f"component_constraint_map={json.dumps(component_map)}\n")
+        f.write(f"app_constraint_map={json.dumps(app_map)}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/validate-descriptor-template.py
+++ b/.github/scripts/validate-descriptor-template.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate constraint-prefixed versions in a platform descriptor template file.
+
+Usage: python3 validate-descriptor-template.py <template-file>
+
+Exit codes:
+  0 - validation passed
+  1 - validation failed (errors printed as GitHub Actions annotations)
+"""
+
+import json
+import re
+import sys
+
+CONSTRAINT_RE = re.compile(r'^[\^~]?\d+\.\d+\.\d+$')
+PLAIN_VERSION_RE = re.compile(r'^(\d+\.\d+\.\d+|R\d+-\d{4})')
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: validate-descriptor-template.py <template-file>", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1]) as f:
+        tmpl = json.load(f)
+
+    errors = []
+
+    if not PLAIN_VERSION_RE.match(tmpl.get('version', '')):
+        errors.append("top-level 'version' must be plain X.Y.Z or Rx-YYYY")
+
+    for comp in tmpl.get('eureka-components', []):
+        v = comp.get('version', '')
+        if not CONSTRAINT_RE.match(v):
+            errors.append(f"eureka-components[{comp['name']}].version='{v}' is invalid")
+
+    for group in ('required', 'optional'):
+        for app in tmpl.get('applications', {}).get(group, []):
+            v = app.get('version', '')
+            if not CONSTRAINT_RE.match(v):
+                errors.append(f"applications.{group}[{app['name']}].version='{v}' is invalid")
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}")
+        sys.exit(1)
+
+    print("::notice::Template validation passed")
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -43,6 +43,7 @@ jobs:
         uses: folio-org/kitfox-github/.github/actions/get-update-config@master
         with:
           repo: ${{ github.repository }}
+          branch: master
           github_token: ${{ github.token }}
 
   update-branches:

--- a/.github/workflows/release-update-flow.yml
+++ b/.github/workflows/release-update-flow.yml
@@ -165,26 +165,56 @@ jobs:
           validate_json: true
           fail_on_missing: true
 
+      - name: 'Detect descriptor template'
+        id: detect-template
+        run: |
+          TEMPLATE_FILE="platform-descriptor-template.json"
+          if [ -f "$TEMPLATE_FILE" ]; then
+            echo "template_exists=true" >> "$GITHUB_OUTPUT"
+            echo "source_file=$TEMPLATE_FILE" >> "$GITHUB_OUTPUT"
+            echo "::notice::Template file found: $TEMPLATE_FILE"
+          else
+            echo "template_exists=false" >> "$GITHUB_OUTPUT"
+            echo "source_file=$STATE_FILE" >> "$GITHUB_OUTPUT"
+            echo "::notice::No template found; using $STATE_FILE"
+          fi
+
+      - name: 'Validate descriptor template'
+        if: steps.detect-template.outputs.template_exists == 'true'
+        uses: folio-org/platform-lsp/.github/actions/validate-descriptor-template@master
+        with:
+          template-file: ${{ steps.detect-template.outputs.source_file }}
+
       - name: 'Extract descriptor fields'
         id: read-descriptor
         uses: folio-org/platform-lsp/.github/actions/extract-descriptor-fields@master
         with:
-          file-path: ${{ env.STATE_FILE }}
+          file-path: ${{ steps.detect-template.outputs.source_file }}
           fields: 'eureka-components,applications'
           validate-schema: 'true'
           expected-types: '{"eureka-components":"array","applications":"object"}'
+
+      - name: 'Build constraint map from template'
+        id: build-constraint-map
+        if: steps.detect-template.outputs.template_exists == 'true'
+        uses: folio-org/platform-lsp/.github/actions/build-constraint-map@master
+        with:
+          eureka-components: ${{ steps.read-descriptor.outputs.eureka-components }}
+          applications: ${{ steps.read-descriptor.outputs.applications }}
 
       - name: 'Update Eureka Components'
         id: update-eureka-components
         uses: folio-org/platform-lsp/.github/actions/update-eureka-components@master
         with:
           components: ${{ steps.read-descriptor.outputs.eureka-components }}
+          constraint-map: ${{ steps.build-constraint-map.outputs.component-constraint-map || '{}' }}
 
       - name: 'Update Applications'
         id: update-applications
         uses: folio-org/platform-lsp/.github/actions/update-applications@master
         with:
           applications: ${{ steps.read-descriptor.outputs.applications }}
+          constraint-map: ${{ steps.build-constraint-map.outputs.app-constraint-map || '{}' }}
 
       - name: 'Compare Components & Applications'
         id: compare-components


### PR DESCRIPTION
## Summary

- Add `constraint-map` input to `update-applications` and `update-eureka-components` actions, allowing per-entry version scope overrides (`minor` | `patch` | `exact`)
- Implement `parse_constraint` to strip and interpret `^`/`~` version prefix semantics from descriptor version strings
- Components/apps with `exact` scope are pinned and skipped during version query
- Add new composite actions: `build-constraint-map` and `validate-descriptor-template`
- Update `release-update-flow.yml` to detect `platform-descriptor-template.json`, validate it, build constraint maps, and pass them to update steps
- Fix `release-scan.yml` to pin `get-update-config` call to `master` branch

## Jira

[RANCHER-2861](https://folio-org.atlassian.net/browse/RANCHER-2861)

## Test plan

- [x] Verify `update-applications` and `update-eureka-components` actions respect `constraint-map` input
- [x] Verify `^` prefix maps to `minor`, `~` to `patch`, and bare version to `exact`
- [x] Verify `exact`-pinned entries are skipped (no version query)
- [x] Verify `build-constraint-map` action correctly produces `component-constraint-map` and `app-constraint-map` outputs
- [x] Verify `validate-descriptor-template` action fails on invalid template
- [x] Verify workflow falls back gracefully when `platform-descriptor-template.json` is absent

🤖 Generated with [Codemie Code](https://github.com/codemie-ai/codemie-code)