### PR TITLE
EUREKA-883: Bump lodash 4.17.21 -> ^4.18.1 fix CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@folio/stripes-authorization-components": "2.0.8",
     "colors": "1.4.0",
     "final-form": "^4.20.4",
+    "lodash": "^4.18.0",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
     "qs": "^6.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,10 +6427,10 @@ lodash.groupby@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
   integrity sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==
 
-lodash@^4.16.4, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.16.4, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EUREKA-883

Bump lodash from 4.17.21 to ^4.18.0 in resolutions section of package.json.

This fixes

* https://github.com/advisories/GHSA-xxjr-mmjv-4gpg CVE-2025-13465 - lodash prototype pollution
* https://github.com/advisories/GHSA-f23m-r3pf-42rh CVE-2026-2950 - lodash Prototype Pollution
* https://github.com/advisories/GHSA-r5fr-rjxr-66jc CVE-2026-4800 - lodash Arbitrary Code Injection