### PR TITLE
Bump @folio/stripes to 10.1.3 and update lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@folio/serials-management": "2.1.0",
     "@folio/service-interaction": "4.1.0",
     "@folio/servicepoints": "9.0.0",
-    "@folio/stripes": "10.0.22",
+    "@folio/stripes": "10.1.3",
     "@folio/stripes-authority-components": "7.0.0",
     "@folio/stripes-build": "1.0.0",
     "@folio/stripes-erm-components": "10.0.0",
@@ -104,8 +104,6 @@
     "zustand": "^4.1.1"
   },
   "resolutions": {
-    "@babel/helpers": "7.26.10",
-    "@babel/runtime": "7.26.10",
     "@rehooks/local-storage": "2.4.5",
     "@folio/stripes-acq-components": "~7.1.0",
     "@folio/stripes-authorization-components": "~2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,13 +210,13 @@
     "@babel/traverse" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/helpers@7.26.10", "@babel/helpers@^7.28.6":
-  version "7.26.10"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.10.tgz#6baea3cd62ec2d0c1068778d63cb1314f6637384"
-  integrity sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==
+"@babel/helpers@^7.28.6":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.2.tgz#9cfbccb02b8e229892c0b07038052cc1a8709c49"
+  integrity sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==
   dependencies:
-    "@babel/template" "^7.26.9"
-    "@babel/types" "^7.26.10"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
 
 "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
   version "7.29.2"
@@ -934,14 +934,19 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime@7.26.10", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.8", "@babel/runtime@^7.24.1", "@babel/runtime@^7.28.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.8", "@babel/runtime@^7.24.1", "@babel/runtime@^7.24.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
   integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.26.9", "@babel/template@^7.28.6":
+"@babel/runtime@^7.28.6":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
+"@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
   integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
@@ -963,7 +968,7 @@
     "@babel/types" "^7.29.0"
     debug "^4.3.1"
 
-"@babel/types@^7.21.3", "@babel/types@^7.26.10", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.4.4":
+"@babel/types@^7.21.3", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.4.4":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
   integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
@@ -2497,16 +2502,17 @@
     webpack-bundle-analyzer "^4.4.2"
     yargs "^17.3.1"
 
-"@folio/stripes-components@~13.0.9":
-  version "13.0.9"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-13.0.9.tgz#6c0cddeb6baca00b67be42544c913d02416672c4"
-  integrity sha512-frzx6dCA1wJEueFOxngg84IrpU4yc+OrjHSxy6ve+9jq1ryEExmu9c5kARf+r/P2Ng6bx+8N7H/WqzXod0BwIw==
+"@folio/stripes-components@~13.1.0":
+  version "13.1.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-13.1.0.tgz#dfee3b5d589dfa70357143110bc17a9ec404fc95"
+  integrity sha512-cvvVzGxW2xmCqqncShsIyiGpFcoRzfJGZfZZ8Yi0B9+wI3bl1v+GXAuNJhZiMrqHLtbob+cWMHlrdihGyGZMig==
   dependencies:
     "@folio/stripes-react-hotkeys" "^3.2.1"
     classnames "^2.2.5"
     currency-codes "2.1.0"
     dayjs "^1.11.10"
-    downshift "^9.0.4"
+    dompurify "^3.3.3"
+    downshift "9.0.13"
     flexboxgrid2 "^7.2.0"
     focus-trap "^7.5.4"
     json2csv "^4.2.1"
@@ -2523,12 +2529,14 @@
     react-quill "^2.0.0"
     react-transition-group "^4.4.5"
     react-virtualized-auto-sizer "^1.0.2"
+    sourcemapped-stacktrace "^1.1.11"
     tai-password-strength "^1.1.1"
+    usehooks-ts "^3.1.1"
 
-"@folio/stripes-connect@~10.0.0":
-  version "10.0.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-10.0.0.tgz#70aa50ee801c3e7d82f66d893cf3bb9af8f25f8c"
-  integrity sha512-HYRaNk97P89e/pOD8BUqFn+6GRm2CDrjFDtsmogRwXnmFn6VJAXw3e7Dcz1cGw9XOPd5RXqGxDnagqfxjDg4Lg==
+"@folio/stripes-connect@~10.1.0":
+  version "10.1.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-10.1.0.tgz#a75281f9f8fe8079d8f4dacc07eacc0508550931"
+  integrity sha512-BwCHLPe0JhHwzALxgcKT64oyb+/DcwjU0+WRgcuQ3AbyddJ0H5HIoyKWwaVfGxOW02JMClFjuACSTWcTp47Fxg==
   dependencies:
     lodash "^4.17.11"
     prop-types "^15.5.10"
@@ -2536,12 +2544,13 @@
     redux "^4.2.1"
     uuid "^9.0.0"
 
-"@folio/stripes-core@~11.0.15":
-  version "11.0.15"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-11.0.15.tgz#acdbfae00264e4bcd1578efba25f20c954d4a762"
-  integrity sha512-BaeAjfh+yxbD7k78A2T8JeZm3uDnGuXNy16mbLAaY2kmqgpc10bD+yIGDOb9m9/Vi4UljKuvdMsW0RMJboL7Bg==
+"@folio/stripes-core@~11.1.2":
+  version "11.1.2"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-11.1.2.tgz#00a4b6451e249b32ce152fe465ccb269a79e7981"
+  integrity sha512-tkR0aA/+J5oTZawR+9XrBmJwKnIuppaW6g2MGnkRwGu3jNkjwyWjGr1NyICZGK2vAbXf8HinsdHsGa2jVHOAeg==
   dependencies:
     "@apollo/client" "^3.2.1"
+    "@module-federation/runtime" "^2.0.0"
     classnames "^2.2.5"
     core-js "^3.26.1"
     final-form "^4.18.2"
@@ -2553,7 +2562,6 @@
     ky "^0.23.0"
     localforage "^1.5.6"
     lodash "^4.17.21"
-    moment-timezone "^0.5.14"
     ms "^2.1.3"
     prop-types "^15.5.10"
     query-string "^7.1.2"
@@ -2561,7 +2569,6 @@
     react-final-form "^6.3.0"
     react-query "^3.6.0"
     react-titled "^2.0.0"
-    react-transform-catch-errors "^1.0.2"
     react-transition-group "^4.4.5"
     redux "^4.0.0"
     redux-form "^8.3.0"
@@ -2571,6 +2578,7 @@
     regenerator-runtime "^0.13.10"
     rtl-detect "^1.0.2"
     rxjs "^6.6.3"
+    semver "^7.7.2"
     use-deep-compare "^1.1.0"
 
 "@folio/stripes-data-transfer-components@^7.0.0", "@folio/stripes-data-transfer-components@^7.1.0":
@@ -2624,7 +2632,7 @@
     react-final-form-arrays "^3.1.0"
     validator "^13.11.0"
 
-"@folio/stripes-final-form@~9.0.0":
+"@folio/stripes-final-form@~9.0.1":
   version "9.0.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-final-form/-/stripes-final-form-9.0.1.tgz#cf992961b0068caf4f877c6554e2f28c63d693a0"
   integrity sha512-P2rG4Swh+iM5A8/5vRkgb7xnO8v+qBApEROE5wwoBpHW+BllJG34hH240lOy7IukKtwgF8qxoTSPWOTIe0hauA==
@@ -2637,10 +2645,10 @@
     react-final-form "^6.3.0"
     react-final-form-arrays "^3.1.0"
 
-"@folio/stripes-form@~10.0.0":
-  version "10.0.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-10.0.0.tgz#282b4fced6357bda91eb8bed91f18752949bfe35"
-  integrity sha512-GqYD15ZBtnzHg6CcBaJhoqLL4c0x/uD3J/9cTiJ4UTBZroUahMX39Ju7MT+pYtQr4cPR3k8kH8mj2EsJH+WREw==
+"@folio/stripes-form@~10.1.0":
+  version "10.1.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-10.1.0.tgz#ced3c73a2732900df18a45f1dc46e3e59c9afb76"
+  integrity sha512-6319S+5z3muCP7CZs3NFRAD2Q9VAIhXnQy2i08DGQltG3DBe48NAVYxnO8t5wq2Bo+NnxD0JaN5RDaNam1wGjQ==
   dependencies:
     flat "^5.0.2"
     prop-types "^15.5.10"
@@ -2697,12 +2705,13 @@
     lodash "^4.17.15"
     prop-types "^15.7.2"
 
-"@folio/stripes-smart-components@~10.0.4":
-  version "10.0.4"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-smart-components/-/stripes-smart-components-10.0.4.tgz#12cd55e9883de7d3979d2c05c96e3c02010e7555"
-  integrity sha512-Sth562MCEXB8wtShr66yLI5hl9ctL+iPzoypWD8xM2iuVF0TF2qowWqUvvRUoATouL8mvE90GJ9GG/oJimEKbg==
+"@folio/stripes-smart-components@~10.1.0":
+  version "10.1.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-smart-components/-/stripes-smart-components-10.1.0.tgz#53181986d0b6fe1b920353b474bd66b561c33eef"
+  integrity sha512-Tkw5FIQoSlE6ucHJBbtS8TsVQ6obciR8rT6XeVDYeSocfF+powFqDDn6zmLans5EZFulazdZPSM1chQp4u+5yQ==
   dependencies:
-    "@rehooks/local-storage" "2.4.4"
+    "@babel/runtime" "^7.28.6"
+    "@rehooks/local-storage" "^2.4.4"
     classnames "^2.2.6"
     dompurify "^3.0.9"
     final-form "^4.18.2"
@@ -2739,23 +2748,10 @@
     react-to-print "^2.3.2"
     uuid "^8.3.2"
 
-"@folio/stripes-types@^3.0.0":
+"@folio/stripes-types@^3.0.0", "@folio/stripes-types@~3.1.1":
   version "3.1.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-types/-/stripes-types-3.1.1.tgz#12c29ada18618eed9ce7042583e8bfc8dcf64b43"
   integrity sha512-lhRp9xisZ46JWasZdtiT/6HzvTbwaKvIfpOWKX+AKwzE5SN92/tbLLnJ25uvfRW1gNWPO/zrmh34FtacVrhDPA==
-  dependencies:
-    "@folio/stripes-react-hotkeys" "^3.0.0"
-    dayjs "^1.11.10"
-    history "^4.10.1"
-    ky "^0.33.3"
-    moment "^2.29.4"
-    popper.js "^1.16.1"
-    type-fest "^4.12.0"
-
-"@folio/stripes-types@~3.0.1":
-  version "3.0.1"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-types/-/stripes-types-3.0.1.tgz#332972f9d485d1eccd4829b35c44ff100648d20c"
-  integrity sha512-TOhWsRDUolW+0r9YwUZRscC4OUVgK0VMYloHgDq5drJTuGaoNR8LE83BxjSl/TA2wuJi3wweg10MTahPLWKiWA==
   dependencies:
     "@folio/stripes-react-hotkeys" "^3.0.0"
     dayjs "^1.11.10"
@@ -2770,19 +2766,10 @@
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-ui/-/stripes-ui-3.0.0.tgz#f89157fc80303e0f9b321b81c762a79b96815ba7"
   integrity sha512-ZgC158bgczJDkHawVPq2d2N0Qk3f0XOg3dELmx92EJjyq2N+Zy7KgOvfTetzltqTtKEDSZz+Mj/VfATmnTV9zw==
 
-"@folio/stripes-util@^7.1.0":
+"@folio/stripes-util@^7.1.0", "@folio/stripes-util@~7.2.0":
   version "7.2.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-7.2.0.tgz#5808a2a13457ee01d9c622daeff869402b0234e4"
   integrity sha512-AmQa8kYNtZgtInNFkmsz79+Euec2VejNzVJjkKeJfND+kn14WCj3LLNkGowcyS5fsFEQVbQQ9+p2JZbi+rUuag==
-  dependencies:
-    json2csv "^4.2.1"
-    lodash "^4.17.4"
-    query-string "^7.1.2"
-
-"@folio/stripes-util@~7.0.1":
-  version "7.0.1"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-7.0.1.tgz#b5e4eabb0c123f351d3e721acc760e87d375d836"
-  integrity sha512-Xkv12m9TEIIVI9huivC/58ByieecAHPnmJlesiZMO9GK5tpRqyaQdXyVUfIBrzBu9GIPkr2h4zCOIeP4vcy+6w==
   dependencies:
     json2csv "^4.2.1"
     lodash "^4.17.4"
@@ -2857,21 +2844,21 @@
     webpack-remove-empty-scripts "^1.0.1"
     webpack-virtual-modules "^0.4.3"
 
-"@folio/stripes@10.0.22":
-  version "10.0.22"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes/-/stripes-10.0.22.tgz#df2f644ab226c113d7a4c1f605ca9bff24071642"
-  integrity sha512-LDwI81bQgCBTPzbF0Msa9DABr0xFJAn/fyh+1FmyImejoNVIggw2Zz8soYgBUiTmqmxtAinN6S21UwAW0zCDPA==
+"@folio/stripes@10.1.3":
+  version "10.1.3"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes/-/stripes-10.1.3.tgz#9d2c9b79521331fbfe2b924e9d51356e3cc9a6ef"
+  integrity sha512-tNiY6IfeyL1InjCXaLGNQonuX7RYaKK+7JlrVtZyot0DPrNpnDjOFpyCYuhaFCf+1uft1KD1+N6SOc+eXhg9/A==
   dependencies:
-    "@folio/stripes-components" "~13.0.9"
-    "@folio/stripes-connect" "~10.0.0"
-    "@folio/stripes-core" "~11.0.15"
-    "@folio/stripes-final-form" "~9.0.0"
-    "@folio/stripes-form" "~10.0.0"
+    "@folio/stripes-components" "~13.1.0"
+    "@folio/stripes-connect" "~10.1.0"
+    "@folio/stripes-core" "~11.1.2"
+    "@folio/stripes-final-form" "~9.0.1"
+    "@folio/stripes-form" "~10.1.0"
     "@folio/stripes-logger" "~1.0.0"
-    "@folio/stripes-smart-components" "~10.0.4"
-    "@folio/stripes-types" "~3.0.1"
+    "@folio/stripes-smart-components" "~10.1.0"
+    "@folio/stripes-types" "~3.1.1"
     "@folio/stripes-ui" "~3.0.0"
-    "@folio/stripes-util" "~7.0.1"
+    "@folio/stripes-util" "~7.2.0"
     redux "^4.2.1"
 
 "@folio/tags@10.0.0":
@@ -3381,7 +3368,7 @@
     "@module-federation/runtime" "2.4.0"
     "@module-federation/webpack-bundler-runtime" "2.4.0"
 
-"@module-federation/runtime@2.4.0":
+"@module-federation/runtime@2.4.0", "@module-federation/runtime@^2.0.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@module-federation/runtime/-/runtime-2.4.0.tgz#094b41f495385368918ce3e7f81207a78b6fe4b7"
   integrity sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==
@@ -3608,7 +3595,7 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
-"@rehooks/local-storage@2.4.4", "@rehooks/local-storage@2.4.5", "@rehooks/local-storage@^2.4.4", "@rehooks/local-storage@^2.4.5":
+"@rehooks/local-storage@2.4.5", "@rehooks/local-storage@^2.4.4", "@rehooks/local-storage@^2.4.5":
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.5.tgz#92c773ce623e168274557499679582cd32749f77"
   integrity sha512-3Q4KtiUBaKoIDRK72BWfAy50ul6hbw29f/M7tyCzlMe2FbSsiQNok0WGeBLaYj4T2PJ7JMSJlSbUGY8RNsImmw==
@@ -4947,7 +4934,7 @@ compressorjs@^1.2.1:
     blueimp-canvas-to-blob "^3.29.0"
     is-blob "^2.1.0"
 
-compute-scroll-into-view@^3.1.1:
+compute-scroll-into-view@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz#02c3386ec531fb6a9881967388e53e8564f3e9aa"
   integrity sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==
@@ -5476,7 +5463,7 @@ domhandler@^5.0, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.0.9, dompurify@^3.1.3, dompurify@^3.2.0, dompurify@^3.3.1:
+dompurify@^3.0.9, dompurify@^3.1.3, dompurify@^3.2.0, dompurify@^3.3.1, dompurify@^3.3.3:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.2.tgz#f0ff81be682c485505097ba8195a058d8f575218"
   integrity sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==
@@ -5523,16 +5510,16 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-downshift@^9.0.4:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-9.3.2.tgz#87d0474e852d8cb77ae948b91abd57763f349a2a"
-  integrity sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==
+downshift@9.0.13:
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-9.0.13.tgz#ed561bb8b57c16bbf5f84064a312b4bf9c4a8150"
+  integrity sha512-fPV+K5jwEzfEAhNhprgCmpWQ23MKwKNzdbtK0QQFiw4hbFcKhMeGB+ccorfWJzmsLR5Dty+CmLDduWlIs74G/w==
   dependencies:
-    "@babel/runtime" "^7.28.6"
-    compute-scroll-into-view "^3.1.1"
+    "@babel/runtime" "^7.24.5"
+    compute-scroll-into-view "^3.1.0"
     prop-types "^15.8.1"
-    react-is "^18.2.0"
-    tslib "^2.8.1"
+    react-is "18.2.0"
+    tslib "^2.6.2"
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -8600,6 +8587,11 @@ react-intl@^7.1.10:
     intl-messageformat "10.7.18"
     tslib "^2.8.0"
 
+react-is@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-is@^16.13.1, react-is@^16.3.2, react-is@^16.4.2, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8610,7 +8602,7 @@ react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^18.0.0, react-is@^18.2.0:
+react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
@@ -8762,11 +8754,6 @@ react-to-print@^3.0.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.3.0.tgz#7c893951b2c621a1c2190cb57a88af40852b129c"
   integrity sha512-7j9GIeNZA9glZlbv9mIbIHDOOx+WYfRMbJzh04NiSKjdaeGkxJuKjJQrtRuNKtt5AvEVVjrLCPokZ9yJX51Fvg==
-
-react-transform-catch-errors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-transform-catch-errors/-/react-transform-catch-errors-1.0.2.tgz#1b4d4a76e97271896fc16fe3086c793ec88a9eeb"
-  integrity sha512-FCeTXLTpRM8wMrwAlYVoEI+HXUFYEJLKdmf9zd5YtH1yc2Dq81JL1YMr0eHeUe699CCTezG4CfEB5D9RpmovEw==
 
 react-transition-group@^4.3.0, react-transition-group@^4.4.5:
   version "4.4.5"
@@ -9245,7 +9232,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.3, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.4:
+semver@^7.1.3, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.4, semver@^7.7.2:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -9445,6 +9432,11 @@ source-map-support@^0.5.16, source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
+
 source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -9459,6 +9451,13 @@ source-map@^0.7.3, source-map@^0.7.4:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
+
+sourcemapped-stacktrace@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz#e2dede7fc148599c52a4f883276e527f8452657d"
+  integrity sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==
+  dependencies:
+    source-map "0.5.6"
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -9823,7 +9822,7 @@ tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.7.0, tslib@^2.8.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -10017,6 +10016,13 @@ use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
+usehooks-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-3.1.1.tgz#0bb7f38f36f8219ee4509cc5e944ae610fb97656"
+  integrity sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==
+  dependencies:
+    lodash.debounce "^4.0.8"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Upgrade @folio/stripes from 10.0.22 to 10.1.3 in package.json and remove explicit resolutions for @babel/helpers and @babel/runtime. Regenerate yarn.lock to align dependency tree with the new stripes version; this pulls updated stripes subpackages and several transitive bumps (e.g. downshift, dompurify, semver) and adds/normalizes auxiliary packages (sourcemapped-stacktrace, usehooks-ts, source-map, updated react-is/tslib entries).