### PR TITLE
RANCHER-2951. Post-release version bump workflow orchestrator

### DIFF
--- a/.github/docs/post-release-bump-orchestrator.md
+++ b/.github/docs/post-release-bump-orchestrator.md
@@ -1,0 +1,149 @@
+# Post-Release Bump Orchestrator
+
+**Workflow**: `platform-lsp/.github/workflows/post-release-bump-orchestrator.yml`
+**Type**: `workflow_dispatch` orchestrator (Kitfox-team operated)
+**Per-app worker**: `kitfox-github/.github/workflows/post-release-bump-flow.yml` (component reference: [post-release-bump-flow.md](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/post-release-bump-flow.md))
+
+This document is the operator runbook: when to fire the orchestrator, what inputs to supply, how to read the results, and how to recover from partial failures. For per-app worker internals (failure-reason codes, the bump sequence, auth scoping), see the flow doc.
+
+## When to Run
+
+Fire this orchestrator **after** `release-preparation-orchestrator.yml` has cut the release branch (e.g., `R1-2026`) from `snapshot` and **after** all team release-prep tickets have landed their constraint updates on the new release branch. At that point every app's `snapshot` branch still carries the same `pom.xml` version as the freshly-cut release branch, which causes:
+
+1. **FAR collision** — descriptors built from `snapshot` would publish under the same coordinates as the release artifacts.
+2. **Branch identity loss** — new snapshot work needs a forward-moving version lineage.
+
+This orchestrator resolves both by, for each app in scope, reading the project version from the release branch's `pom.xml`, computing `<major>.<minor + 1>.0-SNAPSHOT`, and committing that bump directly to the `snapshot` branch.
+
+The orchestrator is **reusable for future releases** — `release_branch` is an input, nothing is hard-coded to a specific release.
+
+## Architecture
+
+```
+[orchestrator: platform-lsp]
+  authorize ──→ setup ──→ bump (matrix) ──→ collect-results ──→ slack_notification ──→ workflow-summary
+                              │
+                              └──→ [flow: kitfox-github, per app]
+                                     prepare-bump ──→ commit-bump (commit-and-push-changes.yml) ──→ upload_results
+```
+
+### Why split across two repos?
+
+Mirrors `release-preparation-orchestrator.yml` (this repo) calling `release-preparation-flow.yml` (kitfox-github). The orchestrator owns "which apps and which release"; the flow owns "how to bump one app".
+
+### Why direct commit to snapshot, not a PR per app?
+
+The bump is a one-line, mechanical edit to `pom.xml`. App `update-config.yml` files already specify `branches.snapshot.need_pr: false` for routine snapshot updates. Reviewer overhead × 40 apps is not justified for a deterministic transformation that is fully reproducible from the inputs (`release_branch` → target version). The audit trail lives in the commit message (which references RANCHER-2951 and the release branch). If a future release calls for PR-based review, swap the per-app worker's `commit-bump` job for `commit-and-push-changes.yml` + `create-pr` without touching the orchestrator.
+
+## Inputs
+
+| Input | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `release_branch` | string | yes | — | Validated against `^R[0-9]+-[0-9]{4}$` (e.g., `R1-2026`). Drives both descriptor lookup (`platform-descriptor.json@<release_branch>`) and per-app target-version computation. |
+| `additional_apps` | string | no | `''` | Apps absent from `platform-descriptor.json` that should also be bumped (comma/space/newline-separated). Used for the RANCHER-2882-pattern apps (`app-rtac-cache`, etc.) and for retry-after-fix workflows. Validated against `^app-[a-z0-9-]+$`. |
+| `excluded_apps` | string | no | `''` | Apps to drop from the final list (comma/space/newline-separated). Use this to skip apps that aren't yet ready (e.g., `app-z3950` until RANCHER-2917 onboards it). |
+| `dry_run` | boolean | no | `false` | When true, runs preflight + version compute + pom edit, but no commit/push and no Slack notification. The step summary and per-app result artifacts still emit. |
+
+## App Scope
+
+The setup job determines the target list as:
+
+```
+final = (descriptor_apps ∪ additional_apps) \ excluded_apps
+```
+
+- **`descriptor_apps`** = `[.applications.required[].name, .applications.optional[].name]` from `platform-descriptor.json` on `<release_branch>`, filtered to names matching `app-*`.
+- **`additional_apps`** = the input list, validated against `^app-[a-z0-9-]+$`.
+- **`excluded_apps`** = the input list. Removed last; an excluded app cannot be smuggled back in via `additional_apps`.
+
+If the resulting list is empty, the orchestrator fails with a clear error. The full final list is logged at the start of the run for operator review — **read it before letting the matrix proceed** if you have any concerns about scope.
+
+## How to Run
+
+1. Confirm `release-preparation-orchestrator.yml` has completed for `<release_branch>` and that team release-prep tickets are merged.
+2. Verify `platform-descriptor.json` on `<release_branch>` reflects the actual release scope (see Troubleshooting → "Stale descriptor" below).
+3. Navigate to **Actions → Post-release bump orchestrator → Run workflow**.
+4. Supply inputs (typical Trillium run):
+   - `release_branch`: `R1-2026`
+   - `additional_apps`: `app-rtac-cache` (and any other RANCHER-2882-pattern apps in scope)
+   - `excluded_apps`: `app-z3950`
+   - `dry_run`: **`true`** for the first invocation
+5. Watch the `setup` job logs to confirm the resolved app list is correct.
+6. Once dry-run passes cleanly, re-dispatch with `dry_run: false`.
+
+## Reading the Results
+
+### Run summary
+
+Generated to the GitHub Actions step summary. Three sections:
+- **Bumped** — apps that received a commit (links to `snapshot` tree + new version).
+- **Skipped** — apps already at or above the target (with the reason).
+- **Failed** — apps that failed at any stage (with `failure_reason`).
+
+### Slack notification
+
+Single aggregate message to the channel configured at `vars.GENERAL_SLACK_NOTIF_CHANNEL`. Color `good` if all apps succeeded; `danger` otherwise. Lists per-app PR links / failure reasons. Suppressed entirely when `dry_run: true`.
+
+### Per-app result artifacts
+
+Each app's flow emits a `result-<app>.json` artifact containing the full status record. Useful for post-run analysis. Schema documented in the flow doc.
+
+## Concurrency & Parallelism
+
+- **Concurrency group**: keyed on `release_branch` — the same release cannot be bumped twice in parallel. Different releases (theoretical) are independent.
+- **`max-parallel: 10`** on the matrix — balances throughput against GitHub API rate-limit headroom.
+- **`fail-fast: false`** — one bad app does not stop the rest.
+
+## First Run / Verification
+
+Walk these phases before relying on this orchestrator for any production release:
+
+**Phase A — static checks**: `actionlint` and `yamllint` on both workflow files locally.
+
+**Phase B — single-app dry run**: dispatch with `release_branch=R1-2026`, `additional_apps=app-platform-minimal`, `excluded_apps` containing every other descriptor app to narrow to one app, `dry_run=true`. Verify the step summary lists `app-platform-minimal` as "would bump" with the expected target version. Confirm no commit landed on `snapshot`.
+
+**Phase C — single-app real run**: same trigger with `dry_run=false`. Confirm a single commit on `app-platform-minimal/snapshot` whose `pom.xml` carries the expected `<version>`. Re-run with the same inputs to verify idempotency (status `skipped`, no second commit).
+
+**Phase D — two-app smoke**: dispatch for two apps in parallel; one should `skip` (left over from Phase C), one should `success`. Confirms `fail-fast: false` and parallelism behave correctly.
+
+**Phase E — full release run**: clean `excluded_apps`, set `additional_apps=app-rtac-cache`, `release_branch=R1-2026`. First with `dry_run=true` to confirm preflight passes for all 40 apps; then with `dry_run=false`. Recovery: feed any failed apps back via `additional_apps` once the root cause is fixed.
+
+**Phase F — post-bump verification**: spot-check 3 apps on the next snapshot CI cycle to confirm the new version publishes to FAR cleanly.
+
+## Troubleshooting
+
+### Stale `platform-descriptor.json` on the release branch
+
+If the descriptor on `<release_branch>` lists fewer apps than the actual release scope, `setup` produces a sub-scope list. Two options:
+- **Preferred**: update the descriptor on the release branch to reflect the actual scope; re-run the orchestrator.
+- **Workaround**: list the missing apps in `additional_apps`. Suitable for ad-hoc fixes; not a substitute for a correct descriptor.
+
+The `setup` job logs the final app list at start-of-run — review it before the matrix proceeds.
+
+### Snapshot already bumped manually
+
+The flow's idempotency check (numeric tuple comparison) handles this: status `skipped`, no commit. Snapshot is never downgraded.
+
+### `pom.xml` version on the release branch isn't clean SemVer
+
+If the release branch's pom carries an unexpected version format (e.g., `-RC1`, build metadata, `-SNAPSHOT`), the app fails with `pom_invalid_release_version`. The bug is on the release-prep side, not here. Investigate the release-prep run for that app before retrying.
+
+### App in scope but missing from the descriptor
+
+This is `app-rtac-cache`'s situation by design — RANCHER-2882 keeps it out of `platform-descriptor.json`. Use `additional_apps`.
+
+### Partial failure — some apps succeeded, others didn't
+
+`fail-fast: false` means the matrix completes regardless of individual failures. Read the run summary's "Failed" section, fix the root cause for each (typically a missing branch, missing descriptor entry, or a malformed pom), then re-run with the failed apps in `additional_apps` and the successful/skipped ones in `excluded_apps`. The flow's idempotency check makes re-running over already-bumped apps a no-op anyway, but narrowing keeps the run small.
+
+## Related Workflows
+
+- `release-preparation-orchestrator.yml` (this repo) — cuts the release branch this orchestrator depends on.
+- `application-update-orchestrator.yml` (this repo) — the routine snapshot module-version updater that runs continuously. Different concern: it bumps module versions inside `application.template.json`, not the project version in `pom.xml`.
+- `approve-run.yml` (this repo) — the reusable team-membership gate used by this orchestrator's `authorize` job.
+
+## Tracking
+
+- RANCHER-2951 — introduces this orchestrator.
+- RANCHER-2917 — `app-z3950` Eureka-CI onboarding (gating its removal from `excluded_apps` for future releases).
+- RANCHER-2882 — pattern for optional apps kept out of `platform-descriptor.json`.

--- a/.github/workflows/post-release-bump-orchestrator.yml
+++ b/.github/workflows/post-release-bump-orchestrator.yml
@@ -1,0 +1,518 @@
+name: Post-release bump orchestrator
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Release branch that was just cut (e.g., R1-2026). Used as the base for the version bump.'
+        required: true
+        type: string
+      additional_apps:
+        description: 'Apps absent from platform-descriptor that should also be bumped (comma/space/newline-separated).'
+        required: false
+        type: string
+        default: ''
+      excluded_apps:
+        description: 'Apps to exclude from the bump (comma/space/newline-separated).'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Perform dry run without committing'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.release_branch }}
+  cancel-in-progress: false
+
+env:
+  PLATFORM_DESCRIPTOR_FILE: 'platform-descriptor.json'
+
+jobs:
+  authorize:
+    name: Authorize Run
+    uses: ./.github/workflows/approve-run.yml
+    with:
+      environment: 'Eureka CI'
+      team: 'kitfox'
+      organization: 'folio-org'
+    secrets: inherit
+
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    needs: authorize
+    outputs:
+      applications: ${{ steps.merge-applications.outputs.applications }}
+      application_count: ${{ steps.merge-applications.outputs.application_count }}
+    env:
+      RELEASE_BRANCH: ${{ inputs.release_branch }}
+    steps:
+      - name: Input parameters
+        env:
+          INPUT_PARAMS: ${{ toJSON(github.event.inputs) }}
+        run: |
+          set -eo pipefail
+
+          echo "::notice::Input parameters"
+          echo "$INPUT_PARAMS" | jq '.'
+
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "::notice::This was a dry run - no actual changes will be made"
+            echo "::notice::Set dry_run=false to apply changes"
+          fi
+
+      - name: Validate Release Branch Format
+        run: |
+          set -eo pipefail
+
+          if [[ ! "$RELEASE_BRANCH" =~ ^R[0-9]+-[0-9]{4}$ ]]; then
+            echo "::error::Invalid release_branch '$RELEASE_BRANCH'. Expected pattern: ^R[0-9]+-[0-9]{4}$ (e.g., R1-2026)"
+            exit 1
+          fi
+          echo "::notice::Release branch format valid: $RELEASE_BRANCH"
+
+      - name: Checkout Release Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+          fetch-depth: 1
+
+      - name: Extract Applications From Platform Descriptor
+        id: extract-applications
+        run: |
+          set -eo pipefail
+
+          if [ ! -f "$PLATFORM_DESCRIPTOR_FILE" ]; then
+            echo "::error::$PLATFORM_DESCRIPTOR_FILE not found on $RELEASE_BRANCH"
+            exit 1
+          fi
+
+          descriptor_apps=$(jq -c '[.applications.required[]?, .applications.optional[]? | select(.name | startswith("app-")) | .name] | unique | sort' "$PLATFORM_DESCRIPTOR_FILE")
+          descriptor_count=$(jq -r 'length' <<<"$descriptor_apps")
+
+          if (( descriptor_count == 0 )); then
+            echo "::error::No applications found in $PLATFORM_DESCRIPTOR_FILE on $RELEASE_BRANCH (or file is malformed)"
+            exit 1
+          fi
+
+          echo "::notice::Found $descriptor_count application(s) in $PLATFORM_DESCRIPTOR_FILE@$RELEASE_BRANCH"
+          jq -r '.[]' <<<"$descriptor_apps" | sed 's/^/  - /'
+          echo "applications=$descriptor_apps" >> "$GITHUB_OUTPUT"
+          echo "application_count=$descriptor_count" >> "$GITHUB_OUTPUT"
+
+      - name: Parse Additional Apps
+        id: parse-additional
+        env:
+          ADDITIONAL_APPS: ${{ inputs.additional_apps }}
+        run: |
+          set -eo pipefail
+
+          additional_json=$(jq -Rn -c --arg input "${ADDITIONAL_APPS:-}" '
+              $input
+              | gsub("[,[:space:]]+"; "\n")
+              | split("\n")
+              | map(select(length>0))
+              | unique
+              | sort
+            ')
+
+          additional_count=$(jq 'length' <<<"$additional_json")
+
+          if (( additional_count > 0 )); then
+            invalid=$(jq -r --argjson apps "$additional_json" -n '$apps[] | select(test("^app-[a-z0-9-]+$") | not)')
+            if [ -n "$invalid" ]; then
+              echo "::error::Invalid app name(s) in additional_apps. Must match ^app-[a-z0-9-]+$:"
+              echo "$invalid" | sed 's/^/  - /'
+              exit 1
+            fi
+            echo "::notice::Found $additional_count additional application(s)"
+            jq -r '.[]' <<<"$additional_json" | sed 's/^/  - /'
+          else
+            echo "::notice::No additional applications specified"
+          fi
+
+          echo "applications=$additional_json" >> "$GITHUB_OUTPUT"
+
+      - name: Parse Excluded Apps
+        id: parse-excluded
+        env:
+          EXCLUDED_APPS: ${{ inputs.excluded_apps }}
+        run: |
+          set -eo pipefail
+
+          excluded_json=$(jq -Rn -c --arg input "${EXCLUDED_APPS:-}" '
+              $input
+              | gsub("[,[:space:]]+"; "\n")
+              | split("\n")
+              | map(select(length>0))
+              | unique
+              | sort
+            ')
+
+          excluded_count=$(jq 'length' <<<"$excluded_json")
+          if (( excluded_count > 0 )); then
+            echo "::notice::Excluding $excluded_count application(s)"
+            jq -r '.[]' <<<"$excluded_json" | sed 's/^/  - /'
+          fi
+
+          echo "applications=$excluded_json" >> "$GITHUB_OUTPUT"
+
+      - name: Merge Applications
+        id: merge-applications
+        env:
+          DESCRIPTOR_APPS: ${{ steps.extract-applications.outputs.applications }}
+          ADDITIONAL_APPS: ${{ steps.parse-additional.outputs.applications }}
+          EXCLUDED_APPS:   ${{ steps.parse-excluded.outputs.applications }}
+        run: |
+          set -eo pipefail
+
+          merged=$(jq -c -n \
+              --argjson descriptor "$DESCRIPTOR_APPS" \
+              --argjson additional "$ADDITIONAL_APPS" \
+              --argjson excluded "$EXCLUDED_APPS" '
+            (($descriptor + $additional) | unique)
+            - $excluded
+            | sort
+          ')
+
+          total=$(jq 'length' <<<"$merged")
+
+          if (( total == 0 )); then
+            echo "::error::Resulting application list is empty after merging descriptor + additional - excluded."
+            exit 1
+          fi
+
+          echo "::notice::Final application list ($total app(s) to bump):"
+          jq -r '.[]' <<<"$merged" | sed 's/^/  - /'
+
+          echo "applications=$merged" >> "$GITHUB_OUTPUT"
+          echo "application_count=$total" >> "$GITHUB_OUTPUT"
+
+  bump:
+    name: Bump ${{ matrix.application }} Snapshot
+    needs: setup
+    strategy:
+      matrix:
+        application: ${{ fromJson(needs.setup.outputs.applications) }}
+      fail-fast: false
+      max-parallel: 10
+    uses: folio-org/kitfox-github/.github/workflows/post-release-bump-flow.yml@master
+    with:
+      app_name: ${{ matrix.application }}
+      repo: folio-org/${{ matrix.application }}
+      release_branch: ${{ inputs.release_branch }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  collect-results:
+    name: Collect Application Results
+    needs: [setup, bump]
+    runs-on: ubuntu-latest
+    if: always() && needs.bump.result != 'skipped'
+    outputs:
+      success_count: ${{ steps.gather.outputs.success_count }}
+      skipped_count: ${{ steps.gather.outputs.skipped_count }}
+      failure_count: ${{ steps.gather.outputs.failure_count }}
+      successful_apps: ${{ steps.gather.outputs.successful_apps }}
+      skipped_apps: ${{ steps.gather.outputs.skipped_apps }}
+      failed_apps: ${{ steps.gather.outputs.failed_apps }}
+      bumped_apps: ${{ steps.gather.outputs.bumped_apps }}
+    steps:
+      - name: Download All Application Results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "result-*"
+          path: /tmp/all-results
+          merge-multiple: true
+
+      - name: Gather Application Results
+        id: gather
+        run: |
+          set -eo pipefail
+
+          echo "::notice::Analyzing application results"
+
+          all=$(jq -s '.' /tmp/all-results/*.json)
+
+          success_count=$(jq '[.[] | select(.status=="success")] | length' <<<"$all")
+          skipped_count=$(jq '[.[] | select(.status=="skipped")] | length' <<<"$all")
+          failure_count=$(jq '[.[] | select(.status=="failed")] | length' <<<"$all")
+
+          successful_apps=$(jq -r '[.[] | select(.status=="success") | .application] | join("\n")' <<<"$all")
+          skipped_apps=$(jq -r '[.[] | select(.status=="skipped") | "\(.application) (\(.skipped_reason // "skipped"))"] | join("\n")' <<<"$all")
+          failed_apps=$(jq -r '[.[] | select(.status=="failed") | "\(.application) (\(.failure_reason // "failed"))"] | join("\n")' <<<"$all")
+
+          bumped_apps=$(jq -r --arg base "${GITHUB_SERVER_URL}" '
+            [.[]
+              | select(.status=="success")
+              | "<\($base)/folio-org/\(.application)/tree/snapshot|\(.application) → \(.new_snapshot_version)>"
+            ]
+            | join("\n")
+          ' <<<"$all")
+
+          echo "::notice::Results - Success: $success_count, Skipped: $skipped_count, Failed: $failure_count"
+
+          {
+            echo "success_count=$success_count"
+            echo "skipped_count=$skipped_count"
+            echo "failure_count=$failure_count"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "successful_apps<<EOF"
+            printf '%s\n' "$successful_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "skipped_apps<<EOF"
+            printf '%s\n' "$skipped_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "failed_apps<<EOF"
+            printf '%s\n' "$failed_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "bumped_apps<<EOF"
+            printf '%s\n' "$bumped_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  slack_notification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [setup, bump, collect-results]
+    if: always() && inputs.dry_run == false
+    outputs:
+      notification_outcome: ${{ steps.send-success.outcome || steps.send-failure.outcome }}
+    env:
+      IS_SUCCESS: >-
+        ${{
+            needs.bump.result == 'failure' && 'false' ||
+            needs.collect-results.result == 'failure' && 'false' ||
+            needs.collect-results.outputs.failure_count != '0' && 'false' ||
+            'true'
+        }}
+    steps:
+      - name: Send SUCCESS Slack Notification
+        id: send-success
+        if: env.IS_SUCCESS == 'true' && vars.GENERAL_SLACK_NOTIF_CHANNEL != ''
+        env:
+          TITLE_TEXT: "Post-Release Bump SUCCESS"
+          TITLE_BLOCK: |
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "*Post-Release Bump SUCCESS <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>*"
+              }
+            }
+          SUCCESS_ATTACHMENT: |
+            {
+              "color": "good",
+              "fields": [
+                {
+                  "title": "Release Branch",
+                  "value": "${{ inputs.release_branch }}",
+                  "short": true
+                },
+                {
+                  "title": "Applications Processed",
+                  "value": "${{ needs.setup.outputs.application_count }}",
+                  "short": true
+                },
+                {
+                  "title": "Bumped",
+                  "value": "${{ needs.collect-results.outputs.success_count }}",
+                  "short": true
+                },
+                {
+                  "title": "Skipped",
+                  "value": "${{ needs.collect-results.outputs.skipped_count }}",
+                  "short": true
+                }
+              ]
+            }
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.EUREKA_CI_SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            {
+              "channel": "${{ vars.GENERAL_SLACK_NOTIF_CHANNEL }}",
+              "text": "${{ env.TITLE_TEXT }}",
+              "blocks": [
+                ${{ env.TITLE_BLOCK }}
+              ],
+              "attachments": [
+                ${{ env.SUCCESS_ATTACHMENT }},
+                {
+                  "color": "good",
+                  "mrkdwn_in": ["text"],
+                  "text": ${{ toJSON(needs.collect-results.outputs.bumped_apps) }},
+                  "footer": "Eureka CI/CD"
+                }
+              ]
+            }
+
+      - name: Send FAILED Slack Notification
+        id: send-failure
+        if: env.IS_SUCCESS == 'false' && vars.GENERAL_SLACK_NOTIF_CHANNEL != ''
+        env:
+          TITLE_TEXT: "Post-Release Bump FAILED"
+          TITLE_BLOCK: |
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "*Post-Release Bump FAILED <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>*"
+              }
+            }
+          FAILURE_ATTACHMENT: |
+            {
+              "color": "danger",
+              "fields": [
+                {
+                  "title": "Release Branch",
+                  "value": "${{ inputs.release_branch }}",
+                  "short": true
+                },
+                {
+                  "title": "Applications Processed",
+                  "value": "${{ needs.setup.outputs.application_count }}",
+                  "short": true
+                },
+                {
+                  "title": "Bumped",
+                  "value": "${{ needs.collect-results.outputs.success_count || '0' }}",
+                  "short": true
+                },
+                {
+                  "title": "Failed",
+                  "value": "${{ needs.collect-results.outputs.failure_count || '0' }}",
+                  "short": true
+                }
+              ]
+            }
+          FAILED_APPS: |
+            {
+              "color": "danger",
+              "mrkdwn_in": ["text"],
+              "text": ${{ toJSON(needs.collect-results.outputs.failed_apps) }},
+              "footer": "Eureka CI/CD"
+            }
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.EUREKA_CI_SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            {
+              "channel": "${{ vars.GENERAL_SLACK_NOTIF_CHANNEL }}",
+              "text": "${{ env.TITLE_TEXT }}",
+              "blocks": [
+                ${{ env.TITLE_BLOCK }}
+              ],
+              "attachments": [
+                ${{ env.FAILURE_ATTACHMENT }},
+                ${{ needs.collect-results.outputs.failure_count != '0' && env.FAILED_APPS || '' }}
+              ]
+            }
+
+  workflow-summary:
+    name: Workflow Summary
+    runs-on: ubuntu-latest
+    needs: [setup, bump, collect-results, slack_notification]
+    if: always()
+    steps:
+      - name: Generate Workflow Summary
+        env:
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          TOTAL_APPS: ${{ needs.setup.outputs.application_count }}
+          SUCCESS_COUNT: ${{ needs.collect-results.outputs.success_count || '0' }}
+          SKIPPED_COUNT: ${{ needs.collect-results.outputs.skipped_count || '0' }}
+          FAILURE_COUNT: ${{ needs.collect-results.outputs.failure_count || '0' }}
+          SUCCESSFUL_APPS: ${{ needs.collect-results.outputs.successful_apps }}
+          SKIPPED_APPS: ${{ needs.collect-results.outputs.skipped_apps }}
+          FAILED_APPS: ${{ needs.collect-results.outputs.failed_apps }}
+          BUMPED_APPS: ${{ needs.collect-results.outputs.bumped_apps }}
+          SETUP_RESULT: ${{ needs.setup.result }}
+          BUMP_RESULT: ${{ needs.bump.result }}
+          COLLECT_RESULT: ${{ needs.collect-results.result }}
+          SLACK_OUTCOME: ${{ needs.slack_notification.outputs.notification_outcome }}
+        run: |
+          set -eo pipefail
+          summary="$GITHUB_STEP_SUMMARY"
+
+          section() { echo -e "\n## $1" >> "$summary"; }
+          line()    { echo "$@" >> "$summary"; }
+
+          print_stats() {
+            line "- **Release Branch**: \`$RELEASE_BRANCH\`"
+            line "- **Total Applications**: $TOTAL_APPS"
+            line "- **Bumped**: $SUCCESS_COUNT"
+            line "- **Skipped**: $SKIPPED_COUNT"
+            line "- **Failed**: $FAILURE_COUNT"
+            line "- **Triggered by**: ${{ github.actor }}"
+            line "- **Run Number**: ${{ github.run_number }}"
+            line ""
+          }
+
+          print_list() {
+            [[ -z "$1" ]] && return
+            echo "$1" | while IFS= read -r item; do
+              if [[ "$item" =~ \<([^|]+)\|([^>]+)\> ]]; then
+                line "- [${BASH_REMATCH[2]}](${BASH_REMATCH[1]})"
+              else
+                [[ -n "$item" ]] && line "- $item"
+              fi
+            done
+          }
+
+          if [[ "$SETUP_RESULT" != "success" ]]; then
+            section "❌ Workflow Aborted - Setup Failed"
+            line "Setup failed. Check the logs for details."
+            exit 0
+          fi
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            section "🏃 Dry Run - Post-Release Bump"
+            print_stats
+            [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### ✅ Would bump:"; print_list "$BUMPED_APPS"; }
+            [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Would skip:"; print_list "$SKIPPED_APPS"; }
+            [[ "$FAILURE_COUNT" -gt 0 ]] && { line "#### ❌ Would fail:"; print_list "$FAILED_APPS"; }
+            exit 0
+          fi
+
+          if [[ "$FAILURE_COUNT" -gt 0 ]]; then
+            section "⚠️ Post-Release Bump - Partial Success"
+            print_stats
+            [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### ✅ Bumped:"; print_list "$BUMPED_APPS"; }
+            [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Skipped:"; print_list "$SKIPPED_APPS"; }
+            line "#### ❌ Failed:"; print_list "$FAILED_APPS"
+            exit 0
+          fi
+
+          section "✅ Post-Release Bump - Success"
+          print_stats
+          [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### 📦 Bumped:"; print_list "$BUMPED_APPS"; }
+          [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Skipped (already at or above target):"; print_list "$SKIPPED_APPS"; }
+
+          section "📨 Notification"
+          if [[ "$DRY_RUN" == "true" ]]; then
+            line "ℹ️ Slack notification skipped (dry run)"
+          else
+            case "$SLACK_OUTCOME" in
+              success) line "✅ Slack notification sent" ;;
+              failure) line "⚠️ Slack notification failed (non-blocking)" ;;
+              *)       line "ℹ️ Slack notification: $SLACK_OUTCOME" ;;
+            esac
+          fi


### PR DESCRIPTION
## Summary

- Add `post-release-bump-orchestrator.yml` — `workflow_dispatch` orchestrator that, after a release branch is cut, bumps each FOLIO app's `snapshot` `pom.xml` version to `<major>.<minor + 1>.0-SNAPSHOT`.
- App scope is derived from `platform-descriptor.json@<release_branch>` (`applications.required` + `applications.optional`), with `additional_apps` and `excluded_apps` inputs for ad-hoc tuning.
- Authorization via the existing `approve-run.yml` gate (Eureka CI environment + kitfox team).
- Matrix fan-out (`max-parallel: 10`, `fail-fast: false`) into the per-app worker in `kitfox-github` — see Dependency below.
- Aggregate result collection, GitHub Step Summary, and single Slack notification (gated only on `dry_run == false`, matching `release-preparation-orchestrator.yml`).
- Add `.github/docs/post-release-bump-orchestrator.md` — operator runbook with when-to-run, inputs reference, app-scope formula, dispatch walkthrough, verification phases A–F, and troubleshooting.

## Motivation

After `release-preparation-orchestrator.yml` cuts a release branch from `snapshot`, every app's `snapshot` branch still carries the same `pom.xml` version as the new release branch. Until this is bumped, snapshot CI descriptors collide with release artifacts on FAR and snapshot loses its forward-moving version lineage. This bump is currently a manual edit per app (40 apps for Trillium). This orchestrator replaces that manual work and is reusable for future releases (`release_branch` is an input, not hard-coded).

## Dependency

This orchestrator calls `folio-org/kitfox-github/.github/workflows/post-release-bump-flow.yml@master` as its per-app worker. That workflow ships in a companion PR against `folio-org/kitfox-github` (to be opened) and must merge first; otherwise dispatching this orchestrator will fail at the matrix step with "workflow not found".

Companion files in kitfox-github:
- `.github/workflows/post-release-bump-flow.yml` — per-app worker (reads release-branch pom, computes target, idempotency check, edits snapshot pom, commits via `commit-and-push-changes.yml`).
- `.github/docs/post-release-bump-flow.md` — component reference (inputs, failure-reason codes, result-artifact schema).

Refs: RANCHER-2951