### PR TITLE
RANCHER-2979. Update workflows to use actions/create-github-app-token@v3

### DIFF
--- a/.github/workflows/approve-run.yml
+++ b/.github/workflows/approve-run.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}

--- a/.github/workflows/toggle-app-workflow.yml
+++ b/.github/workflows/toggle-app-workflow.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.EUREKA_CI_APP_ID }}
           private-key: ${{ secrets.EUREKA_CI_APP_KEY }}


### PR DESCRIPTION
## Summary

- Bump `actions/create-github-app-token@v1` → `@v3` in both Eureka CI workflows in this repo:
  - `.github/workflows/approve-run.yml` (1 call site)
  - `.github/workflows/toggle-app-workflow.yml` (1 call site)
- No surrounding logic touched. The action's input contract (`app-id`, `private-key`, `owner`, `repositories`) and `token` output are unchanged across v1 → v3.

## Motivation

GitHub Actions is deprecating Node.js 20 on runners:
- June 2, 2026 — runners forced to Node.js 24.
- September 16, 2026 — Node.js 20 removed.

`actions/create-github-app-token@v1` runs on Node.js 20 and emits the deprecation warning on every job that mints an App token. v3.1.1 (April 2026) is the latest stable, Node.js 24-based. This PR retires the warning in this repo before the forced cutover.

## Dependency

Companion to `folio-org/kitfox-github` PR #26 (https://github.com/folio-org/kitfox-github/pull/26), which performs the same bump across the 9 reusable workflows in that repo (18 call sites). PRs are independent and can land in either order — each retires its own deprecation warnings on its own workflows.

Refs: RANCHER-2979