### PR TITLE
RANCHER-2984. Fix build-stripes: restore yarn.lock on install failure and propagate error

### DIFF
--- a/.github/workflows/ci-hourly-check.yaml
+++ b/.github/workflows/ci-hourly-check.yaml
@@ -99,20 +99,30 @@ jobs:
         run: |
           set +e
           {
-            rm -f yarn.lock
-            yarn install
-            
-            {
-              echo "## Yarn Dependencies"
-              echo '```'
-              yarn list --pattern @folio
-              echo '```'
-            } >> $GITHUB_STEP_SUMMARY
+            node -v
 
-            current_branch=$(git branch --show-current)
-            git add yarn.lock
-            git commit -m "[CI] Update yarn.lock" || echo "No changes to commit"
-            git push origin $current_branch
+            cp yarn.lock yarn.lock.bak 2>/dev/null || true
+            rm -f yarn.lock
+
+            if ! yarn install; then
+              cp yarn.lock.bak yarn.lock 2>/dev/null || true
+              rm -f yarn.lock.bak
+              false
+            else
+              rm -f yarn.lock.bak
+
+              {
+                echo "## Yarn Dependencies"
+                echo '```'
+                yarn list --pattern @folio
+                echo '```'
+              } >> $GITHUB_STEP_SUMMARY
+
+              current_branch=$(git branch --show-current)
+              git add yarn.lock
+              git commit -m "[CI] Update yarn.lock" || echo "No changes to commit"
+              git push origin $current_branch
+            fi
           } 2>&1 | tee /tmp/build-stripes-output.log
           exit_code=${PIPESTATUS[0]}
           set -e


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                           
- Backup `yarn.lock` before deletion so it can be restored if `yarn install` fails
- Use `if ! yarn install` branching to detect failure and exit with a non-zero code via `PIPESTATUS[0]`, failing the step and triggering the Slack failure notification
- Git commit/push of yarn.lock changes only happens on successful install — prevents committing the deletion of the file

## Root Cause

`set +e` allowed the command group to continue after a failed `yarn install`. The group's exit code was taken from the last command (`git push`), which succeeded after staging and committing the deleted `yarn.lock`. This left the pipeline green while destructively removing the lockfile.

## Test Plan

- [ ] Trigger workflow with a Node.js version incompatible with the required engine — pipeline should fail and Slack failure notification should be sent
- [ ] Verify `yarn.lock` is not deleted/committed when `yarn install` fails
- [x] Trigger workflow with a compatible Node.js version — pipeline should succeed and `yarn.lock` should be updated as before

Fixes: https://folio-org.atlassian.net/browse/RANCHER-2984
