### PR TITLE
RANCHER-2983. Add dependency-refresh phase to post-release-bump orchestrator

### DIFF
--- a/.github/docs/post-release-bump-orchestrator.md
+++ b/.github/docs/post-release-bump-orchestrator.md
@@ -23,7 +23,7 @@ The orchestrator is **reusable for future releases** — `release_branch` is an 
 [orchestrator: platform-lsp]
   authorize ──→ setup ──→ bump (matrix) ──→ dependency-refresh (matrix) ──→ collect-results ──→ slack_notification ──→ workflow-summary
                               │                              │
-                              │                              └──→ [flow: kitfox-github, per app — RANCHER-2983]
+                              │                              └──→ [flow: kitfox-github, per app]
                               │                                     prepare-refresh ──→ commit-refresh ──→ upload_results
                               │
                               └──→ [flow: kitfox-github, per app]

--- a/.github/docs/post-release-bump-orchestrator.md
+++ b/.github/docs/post-release-bump-orchestrator.md
@@ -21,11 +21,18 @@ The orchestrator is **reusable for future releases** — `release_branch` is an 
 
 ```
 [orchestrator: platform-lsp]
-  authorize ──→ setup ──→ bump (matrix) ──→ collect-results ──→ slack_notification ──→ workflow-summary
+  authorize ──→ setup ──→ bump (matrix) ──→ dependency-refresh (matrix) ──→ collect-results ──→ slack_notification ──→ workflow-summary
+                              │                              │
+                              │                              └──→ [flow: kitfox-github, per app — RANCHER-2983]
+                              │                                     prepare-refresh ──→ commit-refresh ──→ upload_results
                               │
                               └──→ [flow: kitfox-github, per app]
                                      prepare-bump ──→ commit-bump (commit-and-push-changes.yml) ──→ upload_results
 ```
+
+Two matrix phases run in series:
+1. **`bump`** — each app's `pom.xml` project version on `snapshot` is bumped to `<release-major>.<release-minor + 1>.0-SNAPSHOT`.
+2. **`dependency-refresh`** — each app's `application.template.json` dependency constraints are refreshed when a dependee's major changed during `bump`. Runs regardless of bump's success (per-app preflight handles its own errors). Stale-only — constraints that still semver-match are left untouched.
 
 ### Why split across two repos?
 
@@ -75,18 +82,32 @@ If the resulting list is empty, the orchestrator fails with a clear error. The f
 
 ### Run summary
 
-Generated to the GitHub Actions step summary. Three sections:
-- **Bumped** — apps that received a commit (links to `snapshot` tree + new version).
-- **Skipped** — apps already at or above the target (with the reason).
-- **Failed** — apps that failed at any stage (with `failure_reason`).
+Generated to the GitHub Actions step summary. Two phases, each with three sections:
+
+**Bump phase:**
+- **Bumped** — apps whose `pom.xml` received a commit (links to `snapshot` tree + new version).
+- **Bump Skipped** — apps already at or above the target.
+- **Bump Failed** — apps that failed at any stage.
+
+**Dependency refresh phase:**
+- **Templates Refreshed** — apps whose `application.template.json` got at least one stale constraint updated (with the count of refreshed entries).
+- **Refresh Skipped** — apps whose constraints all still semver-match (`skipped_reason: no_stale_deps`).
+- **Refresh Failed** — apps that failed at any stage (e.g., missing template, unreadable dependee pom).
 
 ### Slack notification
 
-Single aggregate message to the channel configured at `vars.GENERAL_SLACK_NOTIF_CHANNEL`. Color `good` if all apps succeeded; `danger` otherwise. Lists per-app PR links / failure reasons. Suppressed entirely when `dry_run: true`.
+Single aggregate message to the channel configured at `vars.GENERAL_SLACK_NOTIF_CHANNEL`. Color `good` only if both phases have zero failures; `danger` otherwise. Includes counts for both phases plus a section listing refreshed apps with their refreshed-constraint counts. Suppressed entirely when `dry_run: true`.
 
 ### Per-app result artifacts
 
-Each app's flow emits a `result-<app>.json` artifact containing the full status record. Useful for post-run analysis. Schema documented in the flow doc.
+Each app's bump flow emits a `result-<app>.json` artifact (status record for the bump). Each app's dependency-refresh flow emits a `deprefresh-<app>` artifact containing `<app>-deprefresh.json` (status record + the list of refreshed constraint entries). The orchestrator's `collect-results` job consumes both via separate download patterns (`result-*` and `deprefresh-*`). Schemas documented in the respective flow docs.
+
+### Dependency refresh phase — operator notes
+
+- **When it runs**: immediately after `bump` matrix completes, regardless of bump's success (per-app preflight handles its own errors).
+- **What it does**: for each app, walks `application.template.json` `.dependencies[]`, fetches each dependee's current snapshot version, and rewrites the constraint to `^<dep-major>.<dep-minor>.0-SNAPSHOT` if and only if the existing constraint's major no longer semver-matches.
+- **What it does not touch**: `<app_name>.template.json` (only `application.template.json`), and any constraint whose major still matches.
+- **Idempotency**: re-running on the same target_branch with no stale constraints resolves all apps to `status=skipped, skipped_reason=no_stale_deps` — zero commits.
 
 ## Concurrency & Parallelism
 
@@ -141,9 +162,5 @@ This is `app-rtac-cache`'s situation by design — RANCHER-2882 keeps it out of 
 - `release-preparation-orchestrator.yml` (this repo) — cuts the release branch this orchestrator depends on.
 - `application-update-orchestrator.yml` (this repo) — the routine snapshot module-version updater that runs continuously. Different concern: it bumps module versions inside `application.template.json`, not the project version in `pom.xml`.
 - `approve-run.yml` (this repo) — the reusable team-membership gate used by this orchestrator's `authorize` job.
-
-## Tracking
-
-- RANCHER-2951 — introduces this orchestrator.
-- RANCHER-2917 — `app-z3950` Eureka-CI onboarding (gating its removal from `excluded_apps` for future releases).
-- RANCHER-2882 — pattern for optional apps kept out of `platform-descriptor.json`.
+- `post-release-bump-flow.yml` (kitfox-github) — per-app bump worker. See [`post-release-bump-flow.md`](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/post-release-bump-flow.md).
+- `dependency-refresh-flow.yml` (kitfox-github) — per-app dep-refresh worker. See [`dependency-refresh-flow.md`](https://github.com/folio-org/kitfox-github/blob/master/.github/docs/dependency-refresh-flow.md).

--- a/.github/workflows/post-release-bump-orchestrator.yml
+++ b/.github/workflows/post-release-bump-orchestrator.yml
@@ -210,35 +210,62 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
 
+  dependency-refresh:
+    name: Refresh Dependencies ${{ matrix.application }}
+    needs: [setup, bump]
+    if: always() && needs.setup.result == 'success'
+    strategy:
+      matrix:
+        application: ${{ fromJson(needs.setup.outputs.applications) }}
+      fail-fast: false
+      max-parallel: 10
+    uses: folio-org/kitfox-github/.github/workflows/dependency-refresh-flow.yml@master
+    with:
+      app_name: ${{ matrix.application }}
+      repo: folio-org/${{ matrix.application }}
+      target_branch: snapshot
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
   collect-results:
     name: Collect Application Results
-    needs: [setup, bump]
+    needs: [setup, bump, dependency-refresh]
     runs-on: ubuntu-latest
     if: always() && needs.bump.result != 'skipped'
     outputs:
-      success_count: ${{ steps.gather.outputs.success_count }}
-      skipped_count: ${{ steps.gather.outputs.skipped_count }}
-      failure_count: ${{ steps.gather.outputs.failure_count }}
-      successful_apps: ${{ steps.gather.outputs.successful_apps }}
-      skipped_apps: ${{ steps.gather.outputs.skipped_apps }}
-      failed_apps: ${{ steps.gather.outputs.failed_apps }}
-      bumped_apps: ${{ steps.gather.outputs.bumped_apps }}
+      success_count: ${{ steps.gather-bump.outputs.success_count }}
+      skipped_count: ${{ steps.gather-bump.outputs.skipped_count }}
+      failure_count: ${{ steps.gather-bump.outputs.failure_count }}
+      successful_apps: ${{ steps.gather-bump.outputs.successful_apps }}
+      skipped_apps: ${{ steps.gather-bump.outputs.skipped_apps }}
+      failed_apps: ${{ steps.gather-bump.outputs.failed_apps }}
+      bumped_apps: ${{ steps.gather-bump.outputs.bumped_apps }}
+      deprefresh_success_count: ${{ steps.gather-deprefresh.outputs.deprefresh_success_count }}
+      deprefresh_skipped_count: ${{ steps.gather-deprefresh.outputs.deprefresh_skipped_count }}
+      deprefresh_failure_count: ${{ steps.gather-deprefresh.outputs.deprefresh_failure_count }}
+      deprefresh_apps: ${{ steps.gather-deprefresh.outputs.deprefresh_apps }}
+      deprefresh_failed_apps: ${{ steps.gather-deprefresh.outputs.deprefresh_failed_apps }}
     steps:
-      - name: Download All Application Results
+      - name: Download Bump Results
         uses: actions/download-artifact@v4
         with:
           pattern: "result-*"
           path: /tmp/all-results
           merge-multiple: true
 
-      - name: Gather Application Results
-        id: gather
+      - name: Download Dep-Refresh Results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "deprefresh-*"
+          path: /tmp/all-deprefresh
+          merge-multiple: true
+
+      - name: Gather Bump Results
+        id: gather-bump
         run: |
           set -eo pipefail
 
-          echo "::notice::Analyzing application results"
-
-          all=$(jq -s '.' /tmp/all-results/*.json)
+          all=$(jq -s '.' /tmp/all-results/*.json 2>/dev/null || echo '[]')
 
           success_count=$(jq '[.[] | select(.status=="success")] | length' <<<"$all")
           skipped_count=$(jq '[.[] | select(.status=="skipped")] | length' <<<"$all")
@@ -256,7 +283,7 @@ jobs:
             | join("\n")
           ' <<<"$all")
 
-          echo "::notice::Results - Success: $success_count, Skipped: $skipped_count, Failed: $failure_count"
+          echo "::notice::Bump - Success: $success_count, Skipped: $skipped_count, Failed: $failure_count"
 
           {
             echo "success_count=$success_count"
@@ -284,10 +311,49 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Gather Dep-Refresh Results
+        id: gather-deprefresh
+        run: |
+          set -eo pipefail
+
+          deprefresh_all=$(jq -s '.' /tmp/all-deprefresh/*.json 2>/dev/null || echo '[]')
+
+          deprefresh_success_count=$(jq '[.[] | select(.status=="success")] | length' <<<"$deprefresh_all")
+          deprefresh_skipped_count=$(jq '[.[] | select(.status=="skipped")] | length' <<<"$deprefresh_all")
+          deprefresh_failure_count=$(jq '[.[] | select(.status=="failed")] | length' <<<"$deprefresh_all")
+
+          deprefresh_apps=$(jq -r --arg base "${GITHUB_SERVER_URL}" '
+            [.[]
+              | select(.status=="success" and (.refreshed_count // 0) > 0)
+              | "<\($base)/folio-org/\(.application)/tree/snapshot|\(.application) (\(.refreshed_count) constraint(s))>"
+            ]
+            | join("\n")
+          ' <<<"$deprefresh_all")
+
+          deprefresh_failed_apps=$(jq -r '[.[] | select(.status=="failed") | "\(.application) (\(.failure_reason // "failed"))"] | join("\n")' <<<"$deprefresh_all")
+
+          echo "::notice::Dep-refresh - Success: $deprefresh_success_count, Skipped: $deprefresh_skipped_count, Failed: $deprefresh_failure_count"
+
+          {
+            echo "deprefresh_success_count=$deprefresh_success_count"
+            echo "deprefresh_skipped_count=$deprefresh_skipped_count"
+            echo "deprefresh_failure_count=$deprefresh_failure_count"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "deprefresh_apps<<EOF"
+            printf '%s\n' "$deprefresh_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "deprefresh_failed_apps<<EOF"
+            printf '%s\n' "$deprefresh_failed_apps"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
   slack_notification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [setup, bump, collect-results]
+    needs: [setup, bump, dependency-refresh, collect-results]
     if: always() && inputs.dry_run == false
     outputs:
       notification_outcome: ${{ steps.send-success.outcome || steps.send-failure.outcome }}
@@ -295,8 +361,10 @@ jobs:
       IS_SUCCESS: >-
         ${{
             needs.bump.result == 'failure' && 'false' ||
+            needs.dependency-refresh.result == 'failure' && 'false' ||
             needs.collect-results.result == 'failure' && 'false' ||
             needs.collect-results.outputs.failure_count != '0' && 'false' ||
+            needs.collect-results.outputs.deprefresh_failure_count != '0' && 'false' ||
             'true'
         }}
     steps:
@@ -333,11 +401,28 @@ jobs:
                   "short": true
                 },
                 {
-                  "title": "Skipped",
+                  "title": "Bump Skipped",
                   "value": "${{ needs.collect-results.outputs.skipped_count }}",
+                  "short": true
+                },
+                {
+                  "title": "Templates Refreshed",
+                  "value": "${{ needs.collect-results.outputs.deprefresh_success_count || '0' }}",
+                  "short": true
+                },
+                {
+                  "title": "Refresh Skipped",
+                  "value": "${{ needs.collect-results.outputs.deprefresh_skipped_count || '0' }}",
                   "short": true
                 }
               ]
+            }
+          DEPREFRESH_ATTACHMENT: |
+            {
+              "color": "good",
+              "mrkdwn_in": ["text"],
+              "text": ${{ toJSON(needs.collect-results.outputs.deprefresh_apps) }},
+              "footer": "Eureka CI/CD — Dependency Refresh"
             }
         uses: slackapi/slack-github-action@v2.1.1
         with:
@@ -357,8 +442,9 @@ jobs:
                   "color": "good",
                   "mrkdwn_in": ["text"],
                   "text": ${{ toJSON(needs.collect-results.outputs.bumped_apps) }},
-                  "footer": "Eureka CI/CD"
-                }
+                  "footer": "Eureka CI/CD — Bumped"
+                },
+                ${{ needs.collect-results.outputs.deprefresh_success_count != '0' && env.DEPREFRESH_ATTACHMENT || '' }}
               ]
             }
 
@@ -395,8 +481,18 @@ jobs:
                   "short": true
                 },
                 {
-                  "title": "Failed",
+                  "title": "Bump Failed",
                   "value": "${{ needs.collect-results.outputs.failure_count || '0' }}",
+                  "short": true
+                },
+                {
+                  "title": "Templates Refreshed",
+                  "value": "${{ needs.collect-results.outputs.deprefresh_success_count || '0' }}",
+                  "short": true
+                },
+                {
+                  "title": "Refresh Failed",
+                  "value": "${{ needs.collect-results.outputs.deprefresh_failure_count || '0' }}",
                   "short": true
                 }
               ]
@@ -406,7 +502,14 @@ jobs:
               "color": "danger",
               "mrkdwn_in": ["text"],
               "text": ${{ toJSON(needs.collect-results.outputs.failed_apps) }},
-              "footer": "Eureka CI/CD"
+              "footer": "Eureka CI/CD — Bump Failures"
+            }
+          FAILED_DEPREFRESH_APPS: |
+            {
+              "color": "danger",
+              "mrkdwn_in": ["text"],
+              "text": ${{ toJSON(needs.collect-results.outputs.deprefresh_failed_apps) }},
+              "footer": "Eureka CI/CD — Dep-Refresh Failures"
             }
         uses: slackapi/slack-github-action@v2.1.1
         with:
@@ -422,14 +525,15 @@ jobs:
               ],
               "attachments": [
                 ${{ env.FAILURE_ATTACHMENT }},
-                ${{ needs.collect-results.outputs.failure_count != '0' && env.FAILED_APPS || '' }}
+                ${{ needs.collect-results.outputs.failure_count != '0' && env.FAILED_APPS || '' }},
+                ${{ needs.collect-results.outputs.deprefresh_failure_count != '0' && env.FAILED_DEPREFRESH_APPS || '' }}
               ]
             }
 
   workflow-summary:
     name: Workflow Summary
     runs-on: ubuntu-latest
-    needs: [setup, bump, collect-results, slack_notification]
+    needs: [setup, bump, dependency-refresh, collect-results, slack_notification]
     if: always()
     steps:
       - name: Generate Workflow Summary
@@ -444,8 +548,14 @@ jobs:
           SKIPPED_APPS: ${{ needs.collect-results.outputs.skipped_apps }}
           FAILED_APPS: ${{ needs.collect-results.outputs.failed_apps }}
           BUMPED_APPS: ${{ needs.collect-results.outputs.bumped_apps }}
+          DEPREFRESH_SUCCESS_COUNT: ${{ needs.collect-results.outputs.deprefresh_success_count || '0' }}
+          DEPREFRESH_SKIPPED_COUNT: ${{ needs.collect-results.outputs.deprefresh_skipped_count || '0' }}
+          DEPREFRESH_FAILURE_COUNT: ${{ needs.collect-results.outputs.deprefresh_failure_count || '0' }}
+          DEPREFRESH_APPS: ${{ needs.collect-results.outputs.deprefresh_apps }}
+          DEPREFRESH_FAILED_APPS: ${{ needs.collect-results.outputs.deprefresh_failed_apps }}
           SETUP_RESULT: ${{ needs.setup.result }}
           BUMP_RESULT: ${{ needs.bump.result }}
+          DEPREFRESH_RESULT: ${{ needs.dependency-refresh.result }}
           COLLECT_RESULT: ${{ needs.collect-results.result }}
           SLACK_OUTCOME: ${{ needs.slack_notification.outputs.notification_outcome }}
         run: |
@@ -459,8 +569,11 @@ jobs:
             line "- **Release Branch**: \`$RELEASE_BRANCH\`"
             line "- **Total Applications**: $TOTAL_APPS"
             line "- **Bumped**: $SUCCESS_COUNT"
-            line "- **Skipped**: $SKIPPED_COUNT"
-            line "- **Failed**: $FAILURE_COUNT"
+            line "- **Bump Skipped**: $SKIPPED_COUNT"
+            line "- **Bump Failed**: $FAILURE_COUNT"
+            line "- **Templates Refreshed**: $DEPREFRESH_SUCCESS_COUNT"
+            line "- **Refresh Skipped**: $DEPREFRESH_SKIPPED_COUNT"
+            line "- **Refresh Failed**: $DEPREFRESH_FAILURE_COUNT"
             line "- **Triggered by**: ${{ github.actor }}"
             line "- **Run Number**: ${{ github.run_number }}"
             line ""
@@ -489,22 +602,27 @@ jobs:
             [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### ✅ Would bump:"; print_list "$BUMPED_APPS"; }
             [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Would skip:"; print_list "$SKIPPED_APPS"; }
             [[ "$FAILURE_COUNT" -gt 0 ]] && { line "#### ❌ Would fail:"; print_list "$FAILED_APPS"; }
+            [[ "$DEPREFRESH_SUCCESS_COUNT" -gt 0 ]] && { line "#### 🔄 Would refresh templates:"; print_list "$DEPREFRESH_APPS"; }
+            [[ "$DEPREFRESH_FAILURE_COUNT" -gt 0 ]] && { line "#### ❌ Refresh would fail:"; print_list "$DEPREFRESH_FAILED_APPS"; }
             exit 0
           fi
 
-          if [[ "$FAILURE_COUNT" -gt 0 ]]; then
+          if [[ "$FAILURE_COUNT" -gt 0 || "$DEPREFRESH_FAILURE_COUNT" -gt 0 ]]; then
             section "⚠️ Post-Release Bump - Partial Success"
             print_stats
             [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### ✅ Bumped:"; print_list "$BUMPED_APPS"; }
-            [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Skipped:"; print_list "$SKIPPED_APPS"; }
-            line "#### ❌ Failed:"; print_list "$FAILED_APPS"
+            [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Bump Skipped:"; print_list "$SKIPPED_APPS"; }
+            [[ "$FAILURE_COUNT" -gt 0 ]] && { line "#### ❌ Bump Failed:"; print_list "$FAILED_APPS"; }
+            [[ "$DEPREFRESH_SUCCESS_COUNT" -gt 0 ]] && { line "#### 🔄 Templates Refreshed:"; print_list "$DEPREFRESH_APPS"; }
+            [[ "$DEPREFRESH_FAILURE_COUNT" -gt 0 ]] && { line "#### ❌ Refresh Failed:"; print_list "$DEPREFRESH_FAILED_APPS"; }
             exit 0
           fi
 
           section "✅ Post-Release Bump - Success"
           print_stats
           [[ "$SUCCESS_COUNT" -gt 0 ]] && { line "#### 📦 Bumped:"; print_list "$BUMPED_APPS"; }
-          [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Skipped (already at or above target):"; print_list "$SKIPPED_APPS"; }
+          [[ "$SKIPPED_COUNT" -gt 0 ]] && { line "#### ⏭️ Bump Skipped (already at or above target):"; print_list "$SKIPPED_APPS"; }
+          [[ "$DEPREFRESH_SUCCESS_COUNT" -gt 0 ]] && { line "#### 🔄 Templates Refreshed:"; print_list "$DEPREFRESH_APPS"; }
 
           section "📨 Notification"
           if [[ "$DRY_RUN" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Add `dependency-refresh` matrix job to `post-release-bump-orchestrator.yml`, inserted between `bump` and `collect-results`. Calls the new `dependency-refresh-flow.yml` per app via `secrets: inherit`, same `max-parallel: 10`, `fail-fast: false` as `bump`.
- The new job uses `if: always() && needs.setup.result == 'success'` so it runs even if some `bump` shards failed — per-app preflight in the flow handles its own errors.
- `collect-results` extended: second `download-artifact` step for `deprefresh-*` artifacts, split into two single-responsibility gather steps (`gather-bump`, `gather-deprefresh`), new outputs (`deprefresh_success_count`, `deprefresh_skipped_count`, `deprefresh_failure_count`, `deprefresh_apps`, `deprefresh_failed_apps`).
- `slack_notification` extended: `IS_SUCCESS` now gates on `deprefresh_failure_count` and the `dependency-refresh` job result; success/failure attachments carry counts for both phases plus a dedicated Slack section listing refreshed apps with their refreshed-constraint counts; failure path includes a dep-refresh-failures attachment.
- `workflow-summary` extended: new env vars + sections in the dry-run, partial-success, and success rendering paths so the GitHub Step Summary renders both phases.
- `.github/docs/post-release-bump-orchestrator.md` updated: architecture diagram now shows both matrix phases; new "Dependency refresh phase" operator notes under Reading the Results; Related Workflows + Tracking link to RANCHER-2982 / 2983 and the new kitfox flow doc.

## Motivation

RANCHER-2951's orchestrator bumps each app's `pom.xml` project version after a release branch is cut, but it doesn't touch dependency constraints in `application.template.json`. When a dependee crosses a major boundary during the bump (e.g., `app-acquisitions` 1.X → 2.1.0-SNAPSHOT in Trillium), dependents' `^1.X.X-SNAPSHOT` constraints no longer semver-match and have to be refreshed by hand — RANCHER-2982 documented that manual cleanup across 9 repos. This PR adds the orchestrator-side glue that mechanizes the refresh so it doesn't repeat next release cycle.

## Dependency

Companion to `folio-org/kitfox-github` PR #27 (https://github.com/folio-org/kitfox-github/pull/27), which ships `dependency-refresh-flow.yml` — the per-app worker this orchestrator job calls. PRs can merge in either order; the system is only operational once both are on `master`.

Refs: RANCHER-2983