### PR TITLE
RANCHER-3015 Fix version re-incrementing on each scan when PR is open

### DIFF
--- a/.github/workflows/release-update-flow.yml
+++ b/.github/workflows/release-update-flow.yml
@@ -229,11 +229,25 @@ jobs:
           updated_eureka_components: ${{ steps.update-eureka-components.outputs.updated-components }}
           updated_applications: ${{ steps.update-applications.outputs.updated-applications }}
 
+      - name: 'Extract release branch version for stable versioning'
+        id: extract-release-version
+        if: needs.determine-source-branch.outputs.pr_exists == 'true'
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          RELEASE_VERSION=$(jq -r '.version // empty' platform-descriptor.base.json)
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "::warning::Release branch descriptor has no version field; falling back to update branch version"
+            exit 0
+          fi
+          echo "::notice::PR already open — using release branch version ($RELEASE_VERSION) as base to avoid re-incrementing on each scan"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: 'Calculate New Version'
         id: calculate-new-version
         uses: folio-org/platform-lsp/.github/actions/calculate-version-increment@master
         with:
-          current_version: ${{ steps.compare-components.outputs.previous_version }}
+          current_version: ${{ needs.determine-source-branch.outputs.pr_exists == 'true' && steps.extract-release-version.outputs.release_version || steps.compare-components.outputs.previous_version }}
           changes_detected: ${{ steps.compare-components.outputs.changes_detected }}
 
       - name: 'Apply Descriptor Updates'


### PR DESCRIPTION
## Summary

- When a PR was already open (`version-update/R1-2026` → `R1-2026`), the hourly scan read `previous_version` from the update branch descriptor (which already contained the last bumped version). Each scan that found new FAR component versions cascaded the version upward indefinitely (e.g., `.1 → .2 → .3…`).
- Fix: when `pr_exists == true`, extract the version from the release branch descriptor (already fetched as `platform-descriptor.base.json`) and use it as the base for `calculate-version-increment`. This yields a stable `new_version = release_branch_version + 1` on every scan — components still get updated when FAR has newer versions, but the descriptor version number is not re-bumped.

## Test plan

- [ ] Open a PR for an active release branch (`R1-2026` or `R1-2025-ci`)
- [ ] Trigger the Release Update Scheduler manually (`workflow_dispatch`, `dry_run: false`)
- [ ] Confirm the version is bumped exactly once (e.g., `R1-2026.5 → R1-2026.6`)
- [ ] Trigger the scheduler again while the PR is still open
- [ ] Confirm the version in `platform-descriptor.json` remains unchanged (`R1-2026.6`), even if component versions are updated

Closes: [RANCHER-3015](https://folio-org.atlassian.net/browse/RANCHER-3015)