### PR TITLE
RANCHER-2880. Support #branch version syntax

### DIFF
--- a/scripts/check-apps.sh
+++ b/scripts/check-apps.sh
@@ -81,9 +81,14 @@ echo "Checking required applications:"
 required_apps=$(jq -r '.applications.required[] | "\(.name)|\(.version)"' platform-descriptor.json)
 while IFS='|' read -r app_name current_version; do
     if [ -n "$app_name" ]; then
+        if [[ "$current_version" == \#* ]]; then
+            echo "$app_name: branch-pinned (${current_version}) - skipping FAR check and interface validation"
+            echo ""
+            continue
+        fi
         total_apps=$((total_apps + 1))
         latest_info=$(get_latest_version "$app_name")
-        
+
         if compare_versions "$app_name" "$current_version" "$latest_info"; then
             up_to_date=$((up_to_date + 1))
         else
@@ -102,9 +107,14 @@ echo "Checking optional applications:"
 optional_apps=$(jq -r '.applications.optional[] | "\(.name)|\(.version)"' platform-descriptor.json)
 while IFS='|' read -r app_name current_version; do
     if [ -n "$app_name" ]; then
+        if [[ "$current_version" == \#* ]]; then
+            echo "$app_name: branch-pinned (${current_version}) - skipping FAR check and interface validation"
+            echo ""
+            continue
+        fi
         total_apps=$((total_apps + 1))
         latest_info=$(get_latest_version "$app_name")
-        
+
         if compare_versions "$app_name" "$current_version" "$latest_info"; then
             up_to_date=$((up_to_date + 1))
         else


### PR DESCRIPTION
## Summary

Part of RANCHER-2875 (WS3): allow `platform-descriptor.json` to pin a dependency application to a feature branch via `"version": "#<branch>"` instead of a released semver. This change teaches the snapshot scan script to handle such entries.

A branch-pinned application is not present in FAR, so the hourly scan must not try to look it up or auto-bump it. `check-apps.sh` now skips any entry whose version starts with `#`.

## Changes

- **`scripts/check-apps.sh`** — in both the required and optional application loops, entries whose version starts with `#` are skipped before the FAR latest-version lookup. Such entries are not counted, never added to the interface-validation request, and never auto-bumped; the script logs the skip and continues. Standard semver entries continue to use FAR unchanged.

## Notes

- The companion change in `kitfox-github` `validate-application` action (fetch a `#branch` dependency descriptor from GitHub raw `application.lock.json` instead of FAR) is part of the same ticket and tracked in its own PR.