### PR TITLE
EUREKA-885 bump minimatch to 3.1.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6817,9 +6817,9 @@ mini-css-extract-plugin@^2.7.6:
     tapable "^2.2.1"
 
 minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
Bump `minimatch` to `3.1.5` to address security vulnerabilities
* GHSA-7r86-cg39-jmmj - CVE-2026-27903
* GHSA-3ppc-4f35-3m26 - CVE-2026-26996

Refs [EUREKA-885](https://folio-org.atlassian.net/browse/EUREKA-885)