### PR TITLE
FOLIO-4499 bump dompurify to 3.4.11 fixing numerous vulnerabilities

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,9 +5490,9 @@ domhandler@^5.0, domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 dompurify@^3.0.9, dompurify@^3.1.3, dompurify@^3.2.0, dompurify@^3.3.1, dompurify@^3.3.3:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.2.tgz#f0ff81be682c485505097ba8195a058d8f575218"
-  integrity sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
Bumping to 3.4.11 fixes multiple security vulnerabilities:

* https://security.snyk.io/vuln/SNYK-JS-DOMPURIFY-16078387 – Operator Precedence Logic Error (bypassing FORBID_TAGS)
* CVE-2026-0540 – https://github.com/advisories/GHSA-v2wj-7wpq-c8vv – Cross-site Scripting (XSS)
* CVE-2026-41238 – https://github.com/advisories/GHSA-v9jr-rg53-9pgp – Cross-site Scripting (XSS)
* CVE-2026-41239 – https://github.com/cure53/DOMPurify/security/advisories/GHSA-crv5-9vww-q3g8  – Cross-site Scripting (XSS)
* CVE-2026-41240 – https://github.com/advisories/GHSA-h7mw-gpvr-xq4m – FORBID_TAGS bypassed by function-based ADD_TAGS predicate (asymmetry with FORBID_ATTR fix)
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-cmwh-pvxp-8882 – Permanent `ALLOWED_ATTR` pollution via `setConfig()` bypassing the hook clone-guard
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-vxr8-fq34-vvx9 – Trusted Types policy survives `clearConfig()` and can poison later `RETURN_TRUSTED_TYPE` output
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-gvmj-g25r-r7wr – SAFE_FOR_TEMPLATES bypass - template expressions survive sanitization inside <template> content when using DOM output modes
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-x4vx-rjvf-j5p4 – `IN_PLACE` mode trusts attacker-controlled `nodeName` on live non-form nodes, allowing script retention and XSS via attacker-supplied DOM objects
* CVE-2026-49978 – https://github.com/advisories/GHSA-rp9w-3fw7-7cwq – DOMPurify IN_PLACE Sanitization Bypass via Attached Shadow Root Inside <template>.content
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-76mc-f452-cxcm – Hook mutation of `data.allowedTags` / `data.allowedAttributes` permanently pollutes `DEFAULT_ALLOWED_TAGS` / `DEFAULT_ALLOWED_ATTR`
* CVE-2026-49458 – https://github.com/advisories/GHSA-hpcv-96wg-7vj8 – Cross-realm IN_PLACE sanitization leaves executable markup intact via realm-bound instanceof checks
* CVE-2026-49459 – https://github.com/advisories/GHSA-r47g-fvhr-h676 – IN_PLACE mode preserves attributes of a clobbered root element, allowing XSS via attacker-controlled root DOM
* CVE-2026-47423 – https://github.com/advisories/GHSA-87xg-pxx2-7hvx – DOMPurify XSS via selectedcontent re-clone

Refs [FOLIO-4499](https://folio-org.atlassian.net/browse/FOLIO-4499)