### PR TITLE
RANCHER-3069. Rename descriptor template to platform-descriptor.template.json and declare preRelease

### DIFF
--- a/platform-descriptor.template.json
+++ b/platform-descriptor.template.json
@@ -5,172 +5,213 @@
   "eureka-components": [
     {
       "name": "folio-kong",
-      "version": "^3.9.2"
+      "version": "^3.9.2",
+      "preRelease": "false"
     },
     {
       "name": "folio-keycloak",
-      "version": "^26.5.3"
+      "version": "^26.5.3",
+      "preRelease": "false"
     },
     {
       "name": "folio-module-sidecar",
-      "version": "~4.0.0"
+      "version": "~4.0.0",
+      "preRelease": "false"
     },
     {
       "name": "mgr-applications",
-      "version": "~4.0.0"
+      "version": "~4.0.0",
+      "preRelease": "false"
     },
     {
       "name": "mgr-tenants",
-      "version": "~4.0.0"
+      "version": "~4.0.0",
+      "preRelease": "false"
     },
     {
       "name": "mgr-tenant-entitlements",
-      "version": "~4.0.0"
+      "version": "~4.0.0",
+      "preRelease": "false"
     }
   ],
   "applications": {
     "required": [
       {
         "name": "app-platform-complete",
-        "version": "~3.3.0"
+        "version": "~3.3.0",
+        "preRelease": "false"
       },
       {
         "name": "app-platform-minimal",
-        "version": "~2.1.0"
+        "version": "~2.1.0",
+        "preRelease": "false"
       }
     ],
     "optional": [
       {
         "name": "app-acquisitions",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-agreements",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-authority-records",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-bulk-edit",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-consortia",
-        "version": "~1.4.0"
+        "version": "~1.4.0",
+        "preRelease": "false"
       },
       {
         "name": "app-consortia-manager",
-        "version": "~1.4.0"
+        "version": "~1.4.0",
+        "preRelease": "false"
       },
       {
         "name": "app-dashboard",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-data-export",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-data-import",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-dcb",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-ebsconet",
-        "version": "~1.1.0"
+        "version": "~1.1.0",
+        "preRelease": "false"
       },
       {
         "name": "app-edge-complete",
-        "version": "~2.2.0"
+        "version": "~2.2.0",
+        "preRelease": "false"
       },
       {
         "name": "app-eholdings",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-erm-usage",
-        "version": "~3.0.0"
+        "version": "~3.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-fqm",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-gobi",
-        "version": "~1.1.0"
+        "version": "~1.1.0",
+        "preRelease": "false"
       },
       {
         "name": "app-inn-reach",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-inventory",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-licenses",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-linked-data",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-lists",
-        "version": "~1.1.0"
+        "version": "~1.1.0",
+        "preRelease": "false"
       },
       {
         "name": "app-marc-migrations",
-        "version": "~3.0.0"
+        "version": "~3.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-marc-storage",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-mosaic",
-        "version": "~1.1.0"
+        "version": "~1.1.0",
+        "preRelease": "false"
       },
       {
         "name": "app-notification",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-oai-pmh",
-        "version": "~2.0.0"
+        "version": "~2.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-quick-marc",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-reading-room",
-        "version": "~3.0.0"
+        "version": "~3.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-reporting",
-        "version": "~1.5.0"
+        "version": "~1.5.0",
+        "preRelease": "false"
       },
       {
         "name": "app-rtac",
-        "version": "~1.1.0"
+        "version": "~1.1.0",
+        "preRelease": "false"
       },
       {
         "name": "app-search",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-serials-management",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       },
       {
         "name": "app-service-interaction",
-        "version": "~1.0.0"
+        "version": "~1.0.0",
+        "preRelease": "false"
       }
     ]
   },


### PR DESCRIPTION
Part of RANCHER-3069. Brings this release branch's descriptor template in line with what #190 teaches `release-update-flow.yml` to read.

Two changes to `platform-descriptor-template.json`, both mechanical:

- renamed to **`platform-descriptor.template.json`**
- `"preRelease": "false"` declared on every entry — 6 components and 35 applications

## Why the rename

Three names for the same concept were live at once: `platform.template.json` on `master`, `platform-descriptor-template.json` on the release branches, and nothing at all on `snapshot`.

That is not cosmetic. `release-preparation-orchestrator.yml` checks out `previous_release_branch` and requires the template **on that branch**, but only `master` carried the name it looked for — so `prepare-platform` hard-fails today for any real release branch. One canonical name is the fix.

## Why `preRelease`

`release-update-flow.yml` now reads a `false` | `true` | `only` filter from each entry — the same `PreReleaseFilter` values `folio-application-generator` already uses for `application.template.json`. It drives the FAR query, which candidates survive filtering, and which Docker Hub namespace is listed.

**This is behaviour-neutral.** `false` is the default, and a replay of this branch through the real resolvers against live FAR and Docker Hub produced identical results for all 41 entries before and after the field was added.
