### PR TITLE
RANCHER-3069. Rename descriptor template to platform-descriptor.template.json and declare preRelease

### DIFF
--- a/platform-descriptor.template.json
+++ b/platform-descriptor.template.json
@@ -5,92 +5,113 @@
   "eureka-components": [
     {
       "name": "folio-kong",
-      "version": "^3.9.2"
+      "version": "^3.9.2",
+      "preRelease": "false"
     },
     {
       "name": "folio-keycloak",
-      "version": "^26.5.1"
+      "version": "^26.5.1",
+      "preRelease": "false"
     },
     {
       "name": "folio-module-sidecar",
-      "version": "~3.0.18"
+      "version": "~3.0.18",
+      "preRelease": "false"
     },
     {
       "name": "mgr-applications",
-      "version": "~3.0.6"
+      "version": "~3.0.6",
+      "preRelease": "false"
     },
     {
       "name": "mgr-tenants",
-      "version": "~3.0.6"
+      "version": "~3.0.6",
+      "preRelease": "false"
     },
     {
       "name": "mgr-tenant-entitlements",
-      "version": "~3.1.10"
+      "version": "~3.1.10",
+      "preRelease": "false"
     }
   ],
   "applications": {
     "required": [
       {
         "name": "app-platform-minimal",
-        "version": "~2.0.51"
+        "version": "~2.0.51",
+        "preRelease": "false"
       },
       {
         "name": "app-platform-complete",
-        "version": "~2.5.3"
+        "version": "~2.5.3",
+        "preRelease": "false"
       }
     ],
     "optional": [
       {
         "name": "app-acquisitions",
-        "version": "~1.0.28"
+        "version": "~1.0.28",
+        "preRelease": "false"
       },
       {
         "name": "app-bulk-edit",
-        "version": "~1.0.9"
+        "version": "~1.0.9",
+        "preRelease": "false"
       },
       {
         "name": "app-consortia",
-        "version": "~1.2.3"
+        "version": "~1.2.3",
+        "preRelease": "false"
       },
       {
         "name": "app-consortia-manager",
-        "version": "~1.1.1"
+        "version": "~1.1.1",
+        "preRelease": "false"
       },
       {
         "name": "app-dcb",
-        "version": "~1.1.10"
+        "version": "~1.1.10",
+        "preRelease": "false"
       },
       {
         "name": "app-edge-complete",
-        "version": "~2.0.16"
+        "version": "~2.0.16",
+        "preRelease": "false"
       },
       {
         "name": "app-erm-usage",
-        "version": "~2.0.4"
+        "version": "~2.0.4",
+        "preRelease": "false"
       },
       {
         "name": "app-fqm",
-        "version": "~1.0.15"
+        "version": "~1.0.15",
+        "preRelease": "false"
       },
       {
         "name": "app-inn-reach",
-        "version": "~1.0.6"
+        "version": "~1.0.6",
+        "preRelease": "false"
       },
       {
         "name": "app-linked-data",
-        "version": "~1.1.6"
+        "version": "~1.1.6",
+        "preRelease": "false"
       },
       {
         "name": "app-marc-migrations",
-        "version": "~2.0.5"
+        "version": "~2.0.5",
+        "preRelease": "false"
       },
       {
         "name": "app-oai-pmh",
-        "version": "~1.0.3"
+        "version": "~1.0.3",
+        "preRelease": "false"
       },
       {
         "name": "app-reading-room",
-        "version": "~2.0.2"
+        "version": "~2.0.2",
+        "preRelease": "false"
       }
     ]
   },


### PR DESCRIPTION
Part of RANCHER-3069. Brings this release branch's descriptor template in line with what #190 teaches `release-update-flow.yml` to read.

Two changes to `platform-descriptor-template.json`, both mechanical:

- renamed to **`platform-descriptor.template.json`**
- `"preRelease": "false"` declared on every entry — 6 components and 15 applications

## Why the rename

Three names for the same concept were live at once: `platform.template.json` on `master`, `platform-descriptor-template.json` on the release branches, and nothing at all on `snapshot`.

That is not cosmetic. `release-preparation-orchestrator.yml` checks out `previous_release_branch` and requires the template **on that branch**, but only `master` carried the name it looked for — so `prepare-platform` hard-fails today for any real release branch. One canonical name is the fix.

## Why `preRelease`

`release-update-flow.yml` now reads a `false` | `true` | `only` filter from each entry — the same `PreReleaseFilter` values `folio-application-generator` already uses for `application.template.json`. It drives the FAR query, which candidates survive filtering, and which Docker Hub namespace is listed.

**This is behaviour-neutral.** `false` is the default, and a replay of this branch through the real resolvers against live FAR and Docker Hub produced identical results for all 21 entries before and after the field was added.
